### PR TITLE
Small bug fixes and improvements related to the orographic source, shifting and interpolation in MS-GWaM

### DIFF
--- a/src/init.f90
+++ b/src/init.f90
@@ -416,8 +416,8 @@ module init_module
 
     ! Allocate damping coefficient for unified sponge.
     if(spongeLayer .and. unifiedSponge) then
-      allocate(alphaUnifiedSponge(0:(nx + 1), 0:(ny + 1), 0:(nz + 1)), stat &
-          &= allocstat)
+      allocate(alphaUnifiedSponge((- nbx):(nx + nbx), (- nby):(ny + nby), (- &
+          &nbz):(nz + nbz)), stat = allocstat)
       if(allocstat /= 0) stop "init.f90: could not allocate alphaUnifiedSponge"
     end if
 

--- a/src/output_netcdf.f90
+++ b/src/output_netcdf.f90
@@ -1124,8 +1124,9 @@ module output_netCDF_module
       write(*, fmt = "(a25,i15)") " at time step = ", iTime
       write(*, fmt = "(a25,f15.1,a8)") " at physical time = ", time_dim, " &
           &seconds"
-      write(*, fmt = "(a25,4x,i2.2,a1,i2.2,a1,i2.2,a1,i2.2,a1,i3.3)") "CPU time = ", &
-          &days, "-", hours, ":", minutes, ":", seconds, ":", milliseconds
+      write(*, fmt = "(a25,4x,i2.2,a1,i2.2,a1,i2.2,a1,i2.2,a1,i3.3)") "CPU &
+          &time = ", days, "-", hours, ":", minutes, ":", seconds, ":", &
+          &milliseconds
       print *, "------------------------------------------------"
     end if
 
@@ -2030,5 +2031,5 @@ module output_netCDF_module
       stop 2
     endif
   end subroutine handle_err
- 
+
 end module output_netCDF_module

--- a/src/pinc.f90
+++ b/src/pinc.f90
@@ -412,8 +412,8 @@ program pinc_prog
           &= ray_var3D, tracerforce = tracerforce, waveAmplitudes &
           &= waveAmplitudes, ray = ray)
     elseif(include_ice .and. compute_cloudcover) then
-        call write_netCDF(iOut, iTime, time, cpuTime, var, waveAmplitudes &
-            &= waveAmplitudes, ray_cloud = ray_cloud, sc_ice_field = sc_ice_field)
+      call write_netCDF(iOut, iTime, time, cpuTime, var, waveAmplitudes &
+          &= waveAmplitudes, ray_cloud = ray_cloud, sc_ice_field = sc_ice_field)
     else
       call write_netCDF(iOut, iTime, time, cpuTime, var, ray_var3D &
           &= ray_var3D, waveAmplitudes = waveAmplitudes, ray = ray)
@@ -590,8 +590,8 @@ program pinc_prog
         alphaUnifiedSponge = 0.0
 
         do k = 1, nz
-          do j = 0, ny + 1
-            do i = 0, nx + 1
+          do j = - nby, ny + nby
+            do i = - nbx, nx + nbx
               if(topography) then
                 height = zTFC(i, j, k)
               else
@@ -730,6 +730,8 @@ program pinc_prog
             end do
           end do
         end do
+
+        if(lateralSponge) call setHalosOfField(alphaUnifiedSponge)
 
         alphaUnifiedSponge(:, :, 0) = alphaUnifiedSponge(:, :, 1)
         alphaUnifiedSponge(:, :, nz + 1) = alphaUnifiedSponge(:, :, nz)

--- a/src/types.f90
+++ b/src/types.f90
@@ -276,8 +276,6 @@ module type_module
   ! Number of wave modes (FJApr2023)
   integer :: nwm
 
-  character(len = 10) :: launch_algorithm
-
   real :: zmin_wkb_dim, zmin_wkb
 
   integer :: nray_fac ! maximum factor by which the # of rays may increase
@@ -294,8 +292,8 @@ module type_module
       &sm_filter, lsaturation, alpha_sat, single_column, steady_state, &
       &case_wkb, amp_wkb, wlrx_init, wlry_init, wlrz_init, xr0_dim, yr0_dim, &
       &zr0_dim, sigwpx_dim, sigwpy_dim, sigwpz_dim, branchr, lindUinit, &
-      &blocking, long_threshold, drag_coefficient, nwm, launch_algorithm, &
-      &zmin_wkb_dim, nray_fac, cons_merge ! JaWi: new nml!
+      &blocking, long_threshold, drag_coefficient, nwm, zmin_wkb_dim, &
+      &nray_fac, cons_merge ! JaWi: new nml!
   ! Jan Weinkaemmerer, 27.11.18
 
   !------------------------------------------
@@ -691,6 +689,7 @@ module type_module
 
   real :: relaxation_period
   real :: relaxation_amplitude
+  real, dimension(1:3) :: relaxation_wind
 
   ! boundary types
   character(len = 15) :: xBoundary
@@ -704,7 +703,8 @@ module type_module
       &wFluxCorr, thetaFluxCorr, nbCellCorr, spongeLayer, sponge_uv, &
       &spongeHeight, spongeAlphaZ_dim, spongeAlphaZ_fac, unifiedSponge, &
       &lateralSponge, spongeType, spongeOrder, cosmoSteps, relax_to_mean, &
-      &relaxation_period, relaxation_amplitude, xBoundary, yBoundary, zBoundary
+      &relaxation_period, relaxation_amplitude, relaxation_wind, xBoundary, &
+      &yBoundary, zBoundary
 
   !-----------------------------------------------------------------
   !                     WKB arrays and variables
@@ -1024,7 +1024,6 @@ module type_module
     long_threshold = 0.25
     drag_coefficient = 1.0
     nwm = 1
-    launch_algorithm = "clip"
     zmin_wkb_dim = 0.0
     nray_fac = 10
     cons_merge = "wa"
@@ -1193,6 +1192,7 @@ module type_module
     relax_to_mean = .true.
     relaxation_period = 0.0
     relaxation_amplitude = 0.0
+    relaxation_wind = 0.0
     xBoundary = "periodic"
     yBoundary = "periodic"
     zBoundary = "solid_wall"
@@ -1552,8 +1552,6 @@ module type_module
       call write_float("drag_coefficient", drag_coefficient, "Drag coefficient &
           &of the blocked-layer scheme")
       call write_integer("nwm", nwm, "Number of initial wave modes")
-      call write_character("launch_algorithm", launch_algorithm, "Ray-volume &
-          &launch algorithm")
       call write_float("zmin_wkb_dim", zmin_wkb_dim, "Minimum altitude for &
           &wave-mean-flow interaction")
       call write_integer("nray_fac", nray_fac, "Maximum multiplication factor &
@@ -1842,6 +1840,12 @@ module type_module
       call write_float("relaxation_amplitude", relaxation_amplitude, "Relative &
           &amplitude of an oscillation superposed on the background wind if &
           &unifiedSponge == .true. and relax_to_mean == .false.")
+      do iVar = 1, 3
+        write(counter, "(i2)") iVar
+        call write_float("relaxation_wind(" // trim(adjustl(counter)) // ")", &
+            &relaxation_wind(iVar), "Wind to be obtained via relaxation if &
+            &relax_to_mean == .false.")
+      end do
       call write_character("xBoundary", xBoundary, "Boundary conditions in x &
           &('periodic' only)")
       call write_character("yBoundary", yBoundary, "Boundary conditions in y &

--- a/src/wkb.f90
+++ b/src/wkb.f90
@@ -2531,11 +2531,6 @@ module wkb_module
         kzu = kzTFC(1, 1, zlc)
         kzd = kzu - 1
 
-        if(kzu > nz + 1) then
-          kzu = nz + 1
-          kzd = nz
-        end if
-
         ! Assign the values.
         zd = zTFC(1, 1, kzd)
         zu = zTFC(1, 1, kzu)
@@ -2562,11 +2557,6 @@ module wkb_module
         ! Locate the two closest levels.
         kzu = kzTildeTFC(1, 1, zlc)
         kzd = kzu - 1
-
-        if(kzu + 1 > nz + 1) then
-          kzu = nz
-          kzd = nz - 1
-        end if
 
         ! Assign the values.
         zd = zTildeTFC(1, 1, kzd)
@@ -3042,37 +3032,21 @@ module wkb_module
 
         kzlbu = kzTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz
-          kzlbd = nz
-        end if
         zlbd = zTFC(ixl, jyb, kzlbd)
         zlbu = zTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz
-          kzlfd = nz
-        end if
         zlfd = zTFC(ixl, jyf, kzlfd)
         zlfu = zTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz
-          kzrbd = nz
-        end if
         zrbd = zTFC(ixr, jyb, kzrbd)
         zrbu = zTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz
-          kzrfd = nz
-        end if
         zrfd = zTFC(ixr, jyf, kzrfd)
         zrfu = zTFC(ixr, jyf, kzrfu)
 
@@ -3232,37 +3206,21 @@ module wkb_module
 
         kzlbu = kzTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz
-          kzlbd = nz
-        end if
         zlbd = zTFC(ixl, jyb, kzlbd)
         zlbu = zTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz
-          kzlfd = nz
-        end if
         zlfd = zTFC(ixl, jyf, kzlfd)
         zlfu = zTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz
-          kzrbd = nz
-        end if
         zrbd = zTFC(ixr, jyb, kzrbd)
         zrbu = zTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz
-          kzrfd = nz
-        end if
         zrfd = zTFC(ixr, jyf, kzrfd)
         zrfu = zTFC(ixr, jyf, kzrfu)
 
@@ -3421,37 +3379,21 @@ module wkb_module
 
         kzlbu = kzTildeTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz
-          kzlbd = nz
-        end if
         zlbd = zTildeTFC(ixl, jyb, kzlbd)
         zlbu = zTildeTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTildeTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz
-          kzlfd = nz
-        end if
         zlfd = zTildeTFC(ixl, jyf, kzlfd)
         zlfu = zTildeTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTildeTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz
-          kzrbd = nz
-        end if
         zrbd = zTildeTFC(ixr, jyb, kzrbd)
         zrbu = zTildeTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTildeTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz
-          kzrfd = nz
-        end if
         zrfd = zTildeTFC(ixr, jyf, kzrfd)
         zrfu = zTildeTFC(ixr, jyf, kzrfu)
 
@@ -3667,37 +3609,21 @@ module wkb_module
 
         kzlbu = kzTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz
-          kzlbd = nz
-        end if
         zlbd = zTFC(ixl, jyb, kzlbd)
         zlbu = zTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz
-          kzlfd = nz
-        end if
         zlfd = zTFC(ixl, jyf, kzlfd)
         zlfu = zTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz
-          kzrbd = nz
-        end if
         zrbd = zTFC(ixr, jyb, kzrbd)
         zrbu = zTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz
-          kzrfd = nz
-        end if
         zrfd = zTFC(ixr, jyf, kzrfd)
         zrfu = zTFC(ixr, jyf, kzrfu)
 
@@ -3885,37 +3811,21 @@ module wkb_module
 
         kzlbu = kzTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz
-          kzlbd = nz
-        end if
         zlbd = zTFC(ixl, jyb, kzlbd)
         zlbu = zTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz
-          kzlfd = nz
-        end if
         zlfd = zTFC(ixl, jyf, kzlfd)
         zlfu = zTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz
-          kzrbd = nz
-        end if
         zrbd = zTFC(ixr, jyb, kzrbd)
         zrbu = zTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz
-          kzrfd = nz
-        end if
         zrfd = zTFC(ixr, jyf, kzrfd)
         zrfu = zTFC(ixr, jyf, kzrfu)
 
@@ -4120,37 +4030,21 @@ module wkb_module
 
         kzlbu = kzTildeTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz + 1
-          kzlbd = nz + 1
-        end if
         zlbd = zTildeTFC(ixl, jyb, kzlbd)
         zlbu = zTildeTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTildeTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz + 1
-          kzlfd = nz + 1
-        end if
         zlfd = zTildeTFC(ixl, jyf, kzlfd)
         zlfu = zTildeTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTildeTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz + 1
-          kzrbd = nz + 1
-        end if
         zrbd = zTildeTFC(ixr, jyb, kzrbd)
         zrbu = zTildeTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTildeTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz + 1
-          kzrfd = nz + 1
-        end if
         zrfd = zTildeTFC(ixr, jyf, kzrfd)
         zrfu = zTildeTFC(ixr, jyf, kzrfu)
 
@@ -4495,37 +4389,21 @@ module wkb_module
 
         kzlbu = kzTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz
-          kzlbd = nz
-        end if
         zlbd = zTFC(ixl, jyb, kzlbd)
         zlbu = zTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz
-          kzlfd = nz
-        end if
         zlfd = zTFC(ixl, jyf, kzlfd)
         zlfu = zTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz
-          kzrbd = nz
-        end if
         zrbd = zTFC(ixr, jyb, kzrbd)
         zrbu = zTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz
-          kzrfd = nz
-        end if
         zrfd = zTFC(ixr, jyf, kzrfd)
         zrfu = zTFC(ixr, jyf, kzrfu)
 
@@ -4713,7 +4591,8 @@ module wkb_module
         else
           jyb = floor((ylc - 0.5 * dy - ly(0)) / dy) + 1 - jy0
           if(jyb - 1 < - nby + 1) then
-            print *, "ERROR IN MEANFLOW: jyb - 1 =", jyb - 1, "< - nby + 1 =", - nby + 1
+            print *, "ERROR IN MEANFLOW: jyb - 1 =", jyb - 1, "< - nby + 1 =", &
+                &- nby + 1
             stop
           end if
           jyf = jyb + 1
@@ -4729,37 +4608,21 @@ module wkb_module
 
         kzlbu = kzTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz
-          kzlbd = nz
-        end if
         zlbd = zTFC(ixl, jyb, kzlbd)
         zlbu = zTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz
-          kzlfd = nz
-        end if
         zlfd = zTFC(ixl, jyf, kzlfd)
         zlfu = zTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz
-          kzrbd = nz
-        end if
         zrbd = zTFC(ixr, jyb, kzrbd)
         zrbu = zTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz
-          kzrfd = nz
-        end if
         zrfd = zTFC(ixr, jyf, kzrfd)
         zrfu = zTFC(ixr, jyf, kzrfu)
 
@@ -4945,37 +4808,21 @@ module wkb_module
 
         kzlbu = kzTildeTFC(ixl, jyb, zlc)
         kzlbd = kzlbu - 1
-        if(kzlbd > nz) then
-          kzlbu = nz + 1
-          kzlbd = nz + 1
-        end if
         zlbd = zTildeTFC(ixl, jyb, kzlbd)
         zlbu = zTildeTFC(ixl, jyb, kzlbu)
 
         kzlfu = kzTildeTFC(ixl, jyf, zlc)
         kzlfd = kzlfu - 1
-        if(kzlfd > nz) then
-          kzlfu = nz + 1
-          kzlfd = nz + 1
-        end if
         zlfd = zTildeTFC(ixl, jyf, kzlfd)
         zlfu = zTildeTFC(ixl, jyf, kzlfu)
 
         kzrbu = kzTildeTFC(ixr, jyb, zlc)
         kzrbd = kzrbu - 1
-        if(kzrbd > nz) then
-          kzrbu = nz + 1
-          kzrbd = nz + 1
-        end if
         zrbd = zTildeTFC(ixr, jyb, kzrbd)
         zrbu = zTildeTFC(ixr, jyb, kzrbu)
 
         kzrfu = kzTildeTFC(ixr, jyf, zlc)
         kzrfd = kzrfu - 1
-        if(kzrfd > nz) then
-          kzrfu = nz + 1
-          kzrfd = nz + 1
-        end if
         zrfd = zTildeTFC(ixr, jyf, kzrfd)
         zrfu = zTildeTFC(ixr, jyf, kzrfu)
 
@@ -5641,7 +5488,7 @@ module wkb_module
 
     if(sizeX > 1) then
       call setboundary_rayvol_x(ray)
-      do kzrv = 0, nz + 1
+      do kzrv = 1, nz
         do jyrv = 0, ny + 1
           do ixrv = 0, nx + 1
             do iray = 1, nray(ixrv, jyrv, kzrv)
@@ -5655,8 +5502,8 @@ module wkb_module
                   if(1 <= ix .and. ix <= nx) then
                     nray(ix, jyrv, kzrv) = nray(ix, jyrv, kzrv) + 1
                     jray = nray(ix, jyrv, kzrv)
-                    if(jray > nray_wrk) stop "Error in shift_rayvol: nray > &
-                        &nray_wrk!"
+                    if(jray > nray_wrk) stop "Error in shift_rayvol: nray &
+                        &> nray_wrk!"
                     ray(jray, ix, jyrv, kzrv) = ray(iray, ixrv, jyrv, kzrv)
                   endif
                   ray(iray, ixrv, jyrv, kzrv)%dens = 0.0
@@ -5675,7 +5522,10 @@ module wkb_module
             do iRay = 1, nRay(ix, jy, kz)
               if(ray(iRay, ix, jy, kz)%dens == 0.0) cycle
               nrlc = nrlc + 1
-              ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+              if(nrlc /= iray) then
+                ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+                ray(iRay, ix, jy, kz)%dens = 0.0
+              end if
             end do
             nRay(ix, jy, kz) = nrlc
           end do
@@ -5689,7 +5539,7 @@ module wkb_module
 
     if(sizeY > 1) then
       call setboundary_rayvol_y(ray)
-      do kzrv = 0, nz + 1
+      do kzrv = 1, nz
         do jyrv = 0, ny + 1
           do ixrv = 0, nx + 1
             do iray = 1, nray(ixrv, jyrv, kzrv)
@@ -5703,8 +5553,8 @@ module wkb_module
                   if(1 <= jy .and. jy <= ny) then
                     nray(ixrv, jy, kzrv) = nray(ixrv, jy, kzrv) + 1
                     jray = nray(ixrv, jy, kzrv)
-                    if(jray > nray_wrk) stop "Error in shift_rayvol: nray > &
-                        &nray_wrk!"
+                    if(jray > nray_wrk) stop "Error in shift_rayvol: nray &
+                        &> nray_wrk!"
                     ray(jray, ixrv, jy, kzrv) = ray(iray, ixrv, jyrv, kzrv)
                   endif
                   ray(iray, ixrv, jyrv, kzrv)%dens = 0.0
@@ -5723,7 +5573,10 @@ module wkb_module
             do iRay = 1, nRay(ix, jy, kz)
               if(ray(iRay, ix, jy, kz)%dens == 0.0) cycle
               nrlc = nrlc + 1
-              ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+              if(nrlc /= iray) then
+                ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+                ray(iRay, ix, jy, kz)%dens = 0.0
+              end if
             end do
             nRay(ix, jy, kz) = nrlc
           end do
@@ -5750,15 +5603,16 @@ module wkb_module
                   kz = floor((zr - lz(0)) / dz) + 1
                 end if
 
-                if(kz > nz) kz = nz
-                if(kz < 1) kz = 1
-
                 if(kz /= kzrv) then
-                  nRay(ixrv, jyrv, kz) = nRay(ixrv, jyrv, kz) + 1
-                  jRay = nRay(ixrv, jyrv, kz)
-                  if(jRay > nray_wrk) stop "Error in shift_rayvol: nRay &
-                      &> nray_wrk!"
-                  ray(jRay, ixrv, jyrv, kz) = ray(iRay, ixrv, jyrv, kzrv)
+                  if(abs(kz - kzrv) > 1) stop "Error in shift_rayvol: abs(kz &
+                      &- kzrv) > 1"
+                  if(kz >= 1 .and. kz <= nz) then
+                    nRay(ixrv, jyrv, kz) = nRay(ixrv, jyrv, kz) + 1
+                    jRay = nRay(ixrv, jyrv, kz)
+                    if(jRay > nray_wrk) stop "Error in shift_rayvol: nRay &
+                        &> nray_wrk!"
+                    ray(jRay, ixrv, jyrv, kz) = ray(iRay, ixrv, jyrv, kzrv)
+                  end if
                   ray(iRay, ixrv, jyrv, kzrv)%dens = 0.0
                 end if
               end if
@@ -5775,7 +5629,10 @@ module wkb_module
             do iRay = 1, nRay(ix, jy, kz)
               if(ray(iRay, ix, jy, kz)%dens == 0.0) cycle
               nrlc = nrlc + 1
-              ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+              if(nrlc /= iray) then
+                ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+                ray(iRay, ix, jy, kz)%dens = 0.0
+              end if
             end do
             nRay(ix, jy, kz) = nrlc
           end do
@@ -5784,11 +5641,13 @@ module wkb_module
     end if
 
     ! testb
-    do kz = 1, nz
+    do kz = 0, nz + 1
       do jy = 0, ny + 1
         do ix = 0, nx + 1
           if(nRay(ix, jy, kz) > 0) then
             do iRay = 1, nRay(ix, jy, kz)
+              if(ray(iRay, ix, jy, kz)%dens == 0.0) cycle
+
               if(sizeX > 1) then
                 xr = ray(iRay, ix, jy, kz)%x
 
@@ -8173,7 +8032,7 @@ module wkb_module
     end if
 
     ! Remove ray volumes with zero wave action.
-    do kz = 0, nz + 1
+    do kz = 1, nz
       do jy = 0, ny + 1
         do ix = 0, nx + 1
           if(nRay(ix, jy, kz) <= 0) cycle
@@ -8181,7 +8040,10 @@ module wkb_module
           do iRay = 1, nRay(ix, jy, kz)
             if(ray(iRay, ix, jy, kz)%dens == 0.0) cycle
             nrlc = nrlc + 1
-            ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+            if(nrlc /= iray) then
+              ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+              ray(iRay, ix, jy, kz)%dens = 0.0
+            end if
           end do
           nRay(ix, jy, kz) = nrlc
         end do
@@ -10269,8 +10131,8 @@ module wkb_module
                 yr = ray(iRay, ix, jy, kz)%y
                 ixrv = floor((xr - lx(0)) / dx) + 1 - ix0
                 jyrv = floor((yr - ly(0)) / dy) + 1 - jy0
-                if(zTildeTFC(ixrv, jyrv, 0) - zr + 0.5 * dzr &
-                    &> epsilon(1.0d0)) then
+                if(zTildeTFC(ixrv, jyrv, 0) - zr + 0.5 * dzr > epsilon(1.0d0)) &
+                    &then
                   ray(iRay, ix, jy, kz)%z = 2.0 * zTildeTFC(ixrv, jyrv, 0) &
                       &- zr + dzr
                   ray(iRay, ix, jy, kz)%m = - wnrm
@@ -10283,7 +10145,10 @@ module wkb_module
               end if
 
               nrlc = nrlc + 1
-              if(nrlc /= iray) ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+              if(nrlc /= iray) then
+                ray(nrlc, ix, jy, kz) = ray(iRay, ix, jy, kz)
+                ray(iRay, ix, jy, kz)%dens = 0.0
+              end if
             end do
             nRay(ix, jy, kz) = nrlc
           end do
@@ -10584,21 +10449,24 @@ module wkb_module
             !     new one.
             if(steady_state) then
               if(iRay < 0) then
-                nRay(ix, jy, kz) = nRay(ix, jy, kz) + 1
-                iRay = nRay(ix, jy, kz)
-                ir_sfc(i_sfc, ix, jy) = iRay
-              end if
-
-              if(wadr == 0.0) then
-                ray(iRay, ix, jy, kz)%dens = 0.0
-                cycle
+                if(wadr == 0.0) then
+                  cycle
+                else
+                  nRay(ix, jy, kz) = nRay(ix, jy, kz) + 1
+                  iRay = nRay(ix, jy, kz)
+                  ir_sfc(i_sfc, ix, jy) = iRay
+                end if
+              else if(iRay > 0) then
+                if(wadr == 0.0) then
+                  ray(iRay, ix, jy, kz)%dens = 0.0
+                  ir_sfc(i_sfc, ix, jy) = - 1
+                  cycle
+                end if
               end if
             else
-              if(wadr /= 0.0) then
-                if(launch_algorithm == "scale") iRay = - 1
-
-                ! Check for case (2).
-                if(iRay > 0 .and. zr + 0.5 * dzr > zTildeTFC(ix, jy, kz)) then
+              if(iRay > 0) then
+                ! Shift and clip/extend the old ray volume.
+                if(zr + 0.5 * dzr > zTildeTFC(ix, jy, kz)) then
 
                   ! Shift the old ray volume.
                   nRay(ix, jy, kz + 1) = nRay(ix, jy, kz + 1) + 1
@@ -10606,8 +10474,14 @@ module wkb_module
                   if(nrlc > nray_wrk) stop "Error in orographic_source: nrlc &
                       &> nray_wrk!"
                   ray(nrlc, ix, jy, kz + 1) = ray(iRay, ix, jy, kz)
+                  dxRay(:, nrlc, ix, jy, kz + 1) = dxRay(:, iRay, ix, jy, kz)
+                  dkRay(:, nrlc, ix, jy, kz + 1) = dkRay(:, iRay, ix, jy, kz)
+                  ddxRay(:, nrlc, ix, jy, kz + 1) = ddxRay(:, iRay, ix, jy, kz)
+                  dxRay(:, iRay, ix, jy, kz) = 0.0
+                  dkRay(:, iRay, ix, jy, kz) = 0.0
+                  ddxRay(:, iRay, ix, jy, kz) = 0.0
 
-                  ! Clip or extend the old ray volume.
+                  ! Clip/extend the old ray volume.
                   if(zr - 0.5 * dzr < zTildeTFC(ix, jy, kz) .or. kz2 == 1) then
                     ray(nrlc, ix, jy, kz + 1)%dzray = zr + 0.5 * dzr &
                         &- zTildeTFC(ix, jy, kz)
@@ -10616,31 +10490,23 @@ module wkb_module
                     ray(nrlc, ix, jy, kz + 1)%area_zm = ray(nrlc, ix, jy, kz &
                         &+ 1)%dzray * ray(nrlc, ix, jy, kz + 1)%dmray
                   end if
+                end if
 
-                  ! Check for case (1).
-                elseif(iRay < 0) then
+                if(wadr == 0.0) then
+                  ray(iRay, ix, jy, kz)%dens = 0.0
+                  ir_sfc(i_sfc, ix, jy) = - 1
+                  cycle
+                end if
+              elseif(iRay < 0) then
+                if(wadr == 0.0) then
+                  cycle
+                else
                   nRay(ix, jy, kz) = nRay(ix, jy, kz) + 1
                   iRay = nRay(ix, jy, kz)
                   if(iRay > nray_wrk) stop "Error in orographic_source: iRay &
                       &> nray_wrk!"
                   ir_sfc(i_sfc, ix, jy) = iRay
                 end if
-
-                ! No ray volume is launched for zero wave-action density.
-              else
-                ir_sfc(i_sfc, ix, jy) = - 1
-                cycle
-              end if
-            end if
-
-            ! Scale the wave action density.
-            if(.not. steady_state .and. launch_algorithm == "scale") then
-              cgrz = wnrm * (f_cor_nd ** 2.0 - bvsavg) * wnrh ** 2.0 / omir &
-                  &/ (wnrh ** 2.0 + wnrm ** 2.0) ** 2.0
-              if(topography) then
-                wadr = wadr * dt * cgrz / jac(ix, jy, kz) / dz
-              else
-                wadr = wadr * dt * cgrz / dz
               end if
             end if
 
@@ -10823,42 +10689,33 @@ module wkb_module
     if(topography) then
       kzlbu = kzTFC(ixl, jyb, zlc)
       kzlbd = kzlbu - 1
-      if(kzlbd > nz) then
-        kzlbd = nz
-        kzlbu = nz
-      end if
       zlbd = zTFC(ixl, jyb, kzlbd)
       zlbu = zTFC(ixl, jyb, kzlbu)
-      alphalbd = alphaUnifiedSponge(ixl, jyb, kzlbd)
-      alphalbu = alphaUnifiedSponge(ixl, jyb, kzlbu)
+
       kzlfu = kzTFC(ixl, jyf, zlc)
       kzlfd = kzlfu - 1
-      if(kzlfd > nz) then
-        kzlfd = nz
-        kzlfu = nz
-      end if
       zlfd = zTFC(ixl, jyf, kzlfd)
       zlfu = zTFC(ixl, jyf, kzlfu)
-      alphalfd = alphaUnifiedSponge(ixl, jyf, kzlfd)
-      alphalfu = alphaUnifiedSponge(ixl, jyf, kzlfu)
+
       kzrbu = kzTFC(ixr, jyb, zlc)
       kzrbd = kzrbu - 1
-      if(kzrbd > nz) then
-        kzrbd = nz
-        kzrbu = nz
-      end if
       zrbd = zTFC(ixr, jyb, kzrbd)
       zrbu = zTFC(ixr, jyb, kzrbu)
-      alpharbd = alphaUnifiedSponge(ixr, jyb, kzrbd)
-      alpharbu = alphaUnifiedSponge(ixr, jyb, kzrbu)
+
       kzrfu = kzTFC(ixr, jyf, zlc)
       kzrfd = kzrfu - 1
-      if(kzrfd > nz) then
-        kzrfd = nz
-        kzrfu = nz
-      end if
       zrfd = zTFC(ixr, jyf, kzrfd)
       zrfu = zTFC(ixr, jyf, kzrfu)
+
+      alphalbd = alphaUnifiedSponge(ixl, jyb, kzlbd)
+      alphalbu = alphaUnifiedSponge(ixl, jyb, kzlbu)
+
+      alphalfd = alphaUnifiedSponge(ixl, jyf, kzlfd)
+      alphalfu = alphaUnifiedSponge(ixl, jyf, kzlfu)
+
+      alpharbd = alphaUnifiedSponge(ixr, jyb, kzrbd)
+      alpharbu = alphaUnifiedSponge(ixr, jyb, kzrbu)
+
       alpharfd = alphaUnifiedSponge(ixr, jyf, kzrfd)
       alpharfu = alphaUnifiedSponge(ixr, jyf, kzrfu)
     else
@@ -10975,9 +10832,9 @@ module wkb_module
     real :: zz
 
     kz = minloc(abs(zTFC(ix, jy, :) - zz), dim = 1) - nbz - 1
-    if(zTFC(ix, jy, kz) < zz) kz = kz + 1
-    if(kz < - nbz + 1) kz = - nbz + 1
-    if(kz > nz + nbz) kz = nz + nbz
+    if(zTFC(ix, jy, kz) < zz .and. kz < nz + nbz) kz = kz + 1
+    if(kz < 1) kz = 1
+    if(kz > nz + 1) kz = nz + 1
 
   end function kzTFC
 
@@ -10991,9 +10848,9 @@ module wkb_module
     real :: zz
 
     kz = minloc(abs(zTildeTFC(ix, jy, :) - zz), dim = 1) - nbz - 1
-    if(zTildeTFC(ix, jy, kz) < zz) kz = kz + 1
-    if(kz < - nbz + 1) kz = - nbz + 1
-    if(kz > nz + nbz) kz = nz + nbz
+    if(zTildeTFC(ix, jy, kz) < zz .and. kz < nz + nbz) kz = kz + 1
+    if(kz < 1) kz = 1
+    if(kz > nz) kz = nz
 
   end function kzTildeTFC
 

--- a/tests/input/input_2DWP90_msgwam.f90
+++ b/tests/input/input_2DWP90_msgwam.f90
@@ -186,8 +186,6 @@
                                                      ! blocked-layer scheme
   nwm                      =                       1 ! Number of initial wave
                                                      ! modes
-  launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                     ! algorithm
   zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
                                                      ! wave-mean-flow
                                                      ! interaction

--- a/tests/input/input_IGW.f90
+++ b/tests/input/input_IGW.f90
@@ -180,8 +180,6 @@
                                                      ! blocked-layer scheme
   nwm                      =                       1 ! Number of initial wave
                                                      ! modes
-  launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                     ! algorithm
   zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
                                                      ! wave-mean-flow
                                                      ! interaction

--- a/tests/input/input_barLC.f90
+++ b/tests/input/input_barLC.f90
@@ -184,8 +184,6 @@
                                                      ! blocked-layer scheme
   nwm                      =                       1 ! Number of initial wave
                                                      ! modes
-  launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                     ! algorithm
   zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
                                                      ! wave-mean-flow
                                                      ! interaction

--- a/tests/input/input_coldBubble.f90
+++ b/tests/input/input_coldBubble.f90
@@ -180,8 +180,6 @@
                                                      ! blocked-layer scheme
   nwm                      =                       1 ! Number of initial wave
                                                      ! modes
-  launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                     ! algorithm
   zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
                                                      ! wave-mean-flow
                                                      ! interaction

--- a/tests/input/input_hotBubble3D.f90
+++ b/tests/input/input_hotBubble3D.f90
@@ -180,8 +180,6 @@
                                                      ! blocked-layer scheme
   nwm                      =                       1 ! Number of initial wave
                                                      ! modes
-  launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                     ! algorithm
   zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
                                                      ! wave-mean-flow
                                                      ! interaction

--- a/tests/input/input_mountainwave.f90
+++ b/tests/input/input_mountainwave.f90
@@ -180,8 +180,6 @@
                                                      ! blocked-layer scheme
   nwm                      =                       1 ! Number of initial wave
                                                      ! modes
-  launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                     ! algorithm
   zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
                                                      ! wave-mean-flow
                                                      ! interaction

--- a/tests/input/input_wavePacket3D.f90
+++ b/tests/input/input_wavePacket3D.f90
@@ -180,8 +180,6 @@
                                                      ! blocked-layer scheme
   nwm                      =                       1 ! Number of initial wave
                                                      ! modes
-  launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                     ! algorithm
   zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
                                                      ! wave-mean-flow
                                                      ! interaction

--- a/tests/input/input_wkb_mountain_wave.f90
+++ b/tests/input/input_wkb_mountain_wave.f90
@@ -3,524 +3,630 @@
 !------------------------------------------------------------------------------!
 
 &domain
-sizeX                    =                      40 ! Cells in x
-sizeY                    =                      40 ! Cells in y
-sizeZ                    =                      40 ! Cells in z
-nbx                      =                       3 ! Halo/ghost cells in x
-nby                      =                       3 ! Halo/ghost cells in y
-nbz                      =                       3 ! Ghost cells in z
-lx_dim(0)                =                  0.0E+0 ! Minimum of x
-lx_dim(1)                =                  4.0E+5 ! Maximum of x
-ly_dim(0)                =                  0.0E+0 ! Minimum of y
-ly_dim(1)                =                  4.0E+5 ! Maximum of y
-lz_dim(0)                =                  0.0E+0 ! Minimum of z
-lz_dim(1)                =                  2.0E+4 ! Maximum of z
-nprocx                   =                {nprocx} ! Processors in x
-nprocy                   =                {nprocy} ! Processors in y
+  sizeX                    =                      40 ! Cells in x
+  sizeY                    =                      40 ! Cells in y
+  sizeZ                    =                      40 ! Cells in z
+  nbx                      =                       3 ! Halo/ghost cells in x
+  nby                      =                       3 ! Halo/ghost cells in y
+  nbz                      =                       3 ! Ghost cells in z
+  lx_dim(0)                =                  0.0E+0 ! Minimum of x
+  lx_dim(1)                =                  4.0E+5 ! Maximum of x
+  ly_dim(0)                =                  0.0E+0 ! Minimum of y
+  ly_dim(1)                =                  4.0E+5 ! Maximum of y
+  lz_dim(0)                =                  0.0E+0 ! Minimum of z
+  lz_dim(1)                =                  2.0E+4 ! Maximum of z
+  nprocx                   =                {nprocx} ! Processors in x
+  nprocy                   =                {nprocy} ! Processors in y
 &end
 
 &variables
-include_ice              =                       F ! Ice microphysics
-                                                   ! parameterization
-include_tracer           =                       F ! Tracer equation
-include_testoutput       =                       F ! ...
+  include_ice              =                       F ! Ice microphysics
+                                                     ! parameterization
+  include_tracer           =                       F ! Tracer equation
+  include_testoutput       =                       F ! ...
 &end
 
 &outputList
-atmvarOut(1)             =                     'u' ! Atmospheric output
-                                                   ! variable
-atmvarOut(2)             =                     'v' ! Atmospheric output
-                                                   ! variable
-atmvarOut(3)             =                     'w' ! Atmospheric output
-                                                   ! variable
-rayvarOut(1)             =                    'uw' ! Raytracer output variable
-rayvarOut(2)             =                    'vw' ! Raytracer output variable
-icevarOut(1)             =                      '' ! Ice output variable
-saverayvols              =                       F ! Save ray volumes
-prepare_restart          =                       F ! Save everything needed
-                                                   ! for a restart
-restart                  =                       F ! Restart the model from
-                                                   ! state in previous
-                                                   ! simulation
-iIn                      =                      -1 ! Restart at time step iIn
-runName                  =          'mountainwave' ! Run name for netCDF file
-outputType               =                  'time' ! 'timeStep' or 'time'
-nOutput                  =                       1 ! Output every nOutput
-                                                   ! time steps for
-                                                   ! outputType = 'timeStep'
-maxIter                  =                       1 ! Stop after maxIter time
-                                                   ! steps for outputType =
-                                                   ! 'timeStep'
-outputTimeDiff           =                  3.6E+3 ! Output every
-                                                   ! outputTimeDiff seconds
-                                                   ! for outputType = 'time'
-maxTime                  =                  3.6E+3 ! Stop after maxTime
-                                                   ! seconds for outputType =
-                                                   ! 'time'
-detailedinfo             =                       F ! Provide info on the
-                                                   ! final state of Poisson
-                                                   ! solver
-RHS_diagnostics          =                       T ! Provide info about the
-                                                   ! RHS of Poisson equation
-fancy_namelists          =                       T ! Write all namelists with
-                                                   ! comments
+  atmvarOut(1)             =                     'w' ! Atmospheric output
+                                                     ! variable
+  rayvarOut(1)             =                      '' ! Raytracer output variable
+  icevarOut(1)             =                      '' ! Ice output variable
+  saverayvols              =                       F ! Save ray volumes
+  prepare_restart          =                       F ! Save everything needed
+                                                     ! for a restart
+  restart                  =                       F ! Restart the model from
+                                                     ! state in previous
+                                                     ! simulation
+  iIn                      =                      -1 ! Restart at time step iIn
+  runName                  =          'mountainwave' ! Run name for netCDF file
+  outputType               =                  'time' ! 'timeStep' or 'time'
+  nOutput                  =                       1 ! Output every nOutput
+                                                     ! time steps for
+                                                     ! outputType = 'timeStep'
+  maxIter                  =                       1 ! Stop after maxIter time
+                                                     ! steps for outputType =
+                                                     ! 'timeStep'
+  outputTimeDiff           =                  3.6E+3 ! Output every
+                                                     ! outputTimeDiff seconds
+                                                     ! for outputType = 'time'
+  maxTime                  =                  3.6E+3 ! Stop after maxTime
+                                                     ! seconds for outputType =
+                                                     ! 'time'
+  detailedinfo             =                       F ! Provide info on the
+                                                     ! final state of Poisson
+                                                     ! solver
+  RHS_diagnostics          =                       T ! Provide info about the
+                                                     ! RHS of Poisson equation
+  fancy_namelists          =                       T ! Write all namelists with
+                                                     ! comments
 &end
 
 &debuggingList
-verbose                  =                       F ! ...
-dtMin_dim                =                  1.0E-5 ! Stop if dt < dtMin
+  verbose                  =                       F ! ...
+  dtMin_dim                =                  1.0E-5 ! Stop if dt < dtMin
 &end
 
 &testCaseList
-testCase                 =             'raytracer' ! Predefined test case
+  testCase                 =             'raytracer' ! Predefined test case
 &end
 
 &monochromeWave
-lambda_dim               =                  6.0E+3 ! Vertical wavelength
+  lambda_dim               =                  6.0E+3 ! Vertical wavelength
 &end
 
 &wavePacket
-wavePacketType           =                       1 ! 1 = Gaussian, 2 = Cosine
-wavePacketDim            =                       2 ! 1 = 1D, 2 = 2D, 3 = 3D
-lambdaX_dim              =                  3.0E+5 ! Wavelength in x (0.0 for
-                                                   ! infinite wavelength)
-lambdaY_dim              =                  0.0E+0 ! Wavelength in y (0.0 for
-                                                   ! infinite wavelength)
-lambdaZ_dim              =                 -1.0E+3 ! Wavelength in z
-amplitudeFactor          =                  0.0E+0 ! Normalized buoyancy
-                                                   ! amplitude
-x0_dim                   =                  4.5E+5 ! Wave-packet center in x
-y0_dim                   =                  2.0E+4 ! Wave-packet center in y
-z0_dim                   =                  3.0E+4 ! Wave-packet center in z
-sigma_dim                =                  5.0E+3 ! Vertical width of
-                                                   ! Gaussian wave packet
-sigma_hor_dim            =                  1.5E+6 ! Cosine distribution
-                                                   ! width in x (0.0 for
-                                                   ! infinite width)
-amp_mod_x                =                  1.0E+0 ! Fractional amplitude
-                                                   ! modulation in x
-sigma_hor_yyy_dim        =                  0.0E+0 ! Cosine distribution
-                                                   ! width in y (0.0 for
-                                                   ! infinite width)
-amp_mod_y                =                  1.0E+0 ! Fractional amplitude
-                                                   ! modulation in y
-L_cos_dim                =                  1.0E+4 ! Half width of vertical
-                                                   ! cosine profile of wave
-                                                   ! packet
-omiSign                  =                       1 ! Frequency branch
-u0_jet_dim               =                  0.0E+0 ! Maximum amplitude of jet
-z0_jet_dim               =                  5.0E+4 ! Center of jet
-L_jet_dim                =                  5.0E+3 ! Half width of vertical
-                                                   ! cosine profile of jet
-inducedwind              =                       F ! ...
+  wavePacketType           =                       1 ! 1 = Gaussian, 2 = Cosine
+  wavePacketDim            =                       2 ! 1 = 1D, 2 = 2D, 3 = 3D
+  lambdaX_dim              =                  3.0E+5 ! Wavelength in x (0.0 for
+                                                     ! infinite wavelength)
+  lambdaY_dim              =                  0.0E+0 ! Wavelength in y (0.0 for
+                                                     ! infinite wavelength)
+  lambdaZ_dim              =                 -1.0E+3 ! Wavelength in z
+  amplitudeFactor          =                  0.0E+0 ! Normalized buoyancy
+                                                     ! amplitude
+  x0_dim                   =                  4.5E+5 ! Wave-packet center in x
+  y0_dim                   =                  2.0E+4 ! Wave-packet center in y
+  z0_dim                   =                  3.0E+4 ! Wave-packet center in z
+  sigma_dim                =                  5.0E+3 ! Vertical width of
+                                                     ! Gaussian wave packet
+  sigma_hor_dim            =                  1.5E+6 ! Cosine distribution
+                                                     ! width in x (0.0 for
+                                                     ! infinite width)
+  amp_mod_x                =                  1.0E+0 ! Fractional amplitude
+                                                     ! modulation in x
+  sigma_hor_yyy_dim        =                  0.0E+0 ! Cosine distribution
+                                                     ! width in y (0.0 for
+                                                     ! infinite width)
+  amp_mod_y                =                  1.0E+0 ! Fractional amplitude
+                                                     ! modulation in y
+  L_cos_dim                =                  1.0E+4 ! Half width of vertical
+                                                     ! cosine profile of wave
+                                                     ! packet
+  omiSign                  =                       1 ! Frequency branch
+  u0_jet_dim               =                  0.0E+0 ! Maximum amplitude of jet
+  z0_jet_dim               =                  5.0E+4 ! Center of jet
+  L_jet_dim                =                  5.0E+3 ! Half width of vertical
+                                                     ! cosine profile of jet
+  inducedwind              =                       F ! ...
 &end
 
 &LagrangeRayTracing
-xrmin_dim                =                  0.0E+0 ! Left bound of initial
-                                                   ! rays
-xrmax_dim                =                  4.0E+5 ! Right bound of initial
-                                                   ! rays
-yrmin_dim                =                  0.0E+0 ! Backward bound of
-                                                   ! initial rays
-yrmax_dim                =                  4.0E+5 ! Forward bound of initial
-                                                   ! rays
-zrmin_dim                =                  0.0E+0 ! Bottom bound of initial
-                                                   ! rays
-zrmax_dim                =                  2.0E+4 ! Top bound of initial rays
-nrxl                     =                       1 ! Initial ray volumes
-                                                   ! within dx
-nryl                     =                       1 ! Initial ray volumes
-                                                   ! within dy
-nrzl                     =                       1 ! Initial ray volumes
-                                                   ! within dz
-fac_dk_init              =                  1.0E-1 ! Initial fraction dk/kh
-fac_dl_init              =                  1.0E-1 ! Initial fraction dl/kh
-fac_dm_init              =                  1.0E-1 ! Initial fraction dm/m
-nrk_init                 =                       1 ! Initial ray volumes
-                                                   ! within dk
-nrl_init                 =                       1 ! Initial ray volumes
-                                                   ! within dl
-nrm_init                 =                       1 ! Initial ray volumes
-                                                   ! within dm
-nsmth_wkb                =                       2 ! Width of smoothing
-                                                   ! operator for mean flow
-                                                   ! tendencies
-lsmth_wkb                =                       T ! Smoothing operator for
-                                                   ! mean flow tendencies
-sm_filter                =                       2 ! 1 = Box filter, 2 =
-                                                   ! Shapiro filter
-lsaturation              =                       T ! Switch for saturation
-                                                   ! scheme
-alpha_sat                =                  1.0E+0 ! Saturation threshold
-single_column            =                       F ! Single-column mode
-steady_state             =                       F ! Steady-state mode
-case_wkb                 =                       3 ! 1 = Gaussian wave
-                                                   ! packet, 2 = cosine wave
-                                                   ! packet, 3 = mountain
-                                                   ! wave
-amp_wkb                  =                  5.0E-1 ! Relative amplitude of
-                                                   ! wave packet
-wlrx_init                =                  1.0E+5 ! Wavelength in x of wave
-                                                   ! packet
-wlry_init                =                  0.0E+0 ! Wavelength in y of wave
-                                                   ! packet
-wlrz_init                =                  1.0E+3 ! Wavelength in z of wave
-                                                   ! packet
-xr0_dim                  =                  2.5E+6 ! Wave packet center in x
-yr0_dim                  =                  2.5E+4 ! Wave packet center in y
-zr0_dim                  =                  3.0E+4 ! Wave packet center in z
-sigwpx_dim               =                  1.0E+6 ! Wave packet width in x
-                                                   ! (0.0 for infinite width)
-sigwpy_dim               =                  0.0E+0 ! Wave packet width in y
-                                                   ! (0.0 for infinite width)
-sigwpz_dim               =                  5.0E+3 ! Wave packet width in z
-                                                   ! (0.0 for infinite width)
-branchr                  =                      -1 ! Frequency branch
-lindUinit                =                       F ! Induced wind at initial
-                                                   ! time
-blocking                 =                       F ! Blocked-layer scheme
-long_threshold           =                  2.5E-1 ! Long-number threshold of
-                                                   ! the blocked-layer scheme
-drag_coefficient         =                  1.0E+0 ! Drag coefficient of the
-                                                   ! blocked-layer scheme
-nwm                      =                       1 ! Number of initial wave
-                                                   ! modes
-launch_algorithm         =                  'clip' ! Ray-volume launch
-                                                   ! algorithm
-zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
-                                                   ! wave-mean-flow
-                                                   ! interaction
-nray_fac                 =                       4 ! Maximum multiplication
-                                                   ! factor per spectral
-                                                   ! dimension
-cons_merge               =                    'wa' ! Conserved quantity in
-                                                   ! ray-volume merging ('wa'
-                                                   ! = wave action, 'en' =
-                                                   ! wave energy)
+  xrmin_dim                =                  0.0E+0 ! Left bound of initial
+                                                     ! rays
+  xrmax_dim                =                  4.0E+5 ! Right bound of initial
+                                                     ! rays
+  yrmin_dim                =                  0.0E+0 ! Backward bound of
+                                                     ! initial rays
+  yrmax_dim                =                  4.0E+5 ! Forward bound of initial
+                                                     ! rays
+  zrmin_dim                =                  0.0E+0 ! Bottom bound of initial
+                                                     ! rays
+  zrmax_dim                =                  2.0E+4 ! Top bound of initial rays
+  nrxl                     =                       1 ! Initial ray volumes
+                                                     ! within dx
+  nryl                     =                       1 ! Initial ray volumes
+                                                     ! within dy
+  nrzl                     =                       1 ! Initial ray volumes
+                                                     ! within dz
+  fac_dk_init              =                  1.0E-1 ! Initial fraction dk/kh
+  fac_dl_init              =                  1.0E-1 ! Initial fraction dl/kh
+  fac_dm_init              =                  1.0E-1 ! Initial fraction dm/m
+  nrk_init                 =                       1 ! Initial ray volumes
+                                                     ! within dk
+  nrl_init                 =                       1 ! Initial ray volumes
+                                                     ! within dl
+  nrm_init                 =                       1 ! Initial ray volumes
+                                                     ! within dm
+  nsmth_wkb                =                       2 ! Width of smoothing
+                                                     ! operator for mean flow
+                                                     ! tendencies
+  lsmth_wkb                =                       T ! Smoothing operator for
+                                                     ! mean flow tendencies
+  sm_filter                =                       2 ! 1 = Box filter, 2 =
+                                                     ! Shapiro filter
+  lsaturation              =                       T ! Switch for saturation
+                                                     ! scheme
+  alpha_sat                =                  1.0E+0 ! Saturation threshold
+  single_column            =                       F ! Single-column mode
+  steady_state             =                       F ! Steady-state mode
+  case_wkb                 =                       3 ! 1 = Gaussian wave
+                                                     ! packet, 2 = cosine wave
+                                                     ! packet, 3 = mountain
+                                                     ! wave
+  amp_wkb                  =                  5.0E-1 ! Relative amplitude of
+                                                     ! wave packet
+  wlrx_init                =                  1.0E+5 ! Wavelength in x of wave
+                                                     ! packet
+  wlry_init                =                  0.0E+0 ! Wavelength in y of wave
+                                                     ! packet
+  wlrz_init                =                  1.0E+3 ! Wavelength in z of wave
+                                                     ! packet
+  xr0_dim                  =                  2.5E+6 ! Wave packet center in x
+  yr0_dim                  =                  2.5E+4 ! Wave packet center in y
+  zr0_dim                  =                  3.0E+4 ! Wave packet center in z
+  sigwpx_dim               =                  1.0E+6 ! Wave packet width in x
+                                                     ! (0.0 for infinite width)
+  sigwpy_dim               =                  0.0E+0 ! Wave packet width in y
+                                                     ! (0.0 for infinite width)
+  sigwpz_dim               =                  5.0E+3 ! Wave packet width in z
+                                                     ! (0.0 for infinite width)
+  branchr                  =                      -1 ! Frequency branch
+  lindUinit                =                       F ! Induced wind at initial
+                                                     ! time
+  blocking                 =                       F ! Blocked-layer scheme
+  long_threshold           =                  2.5E-1 ! Long-number threshold of
+                                                     ! the blocked-layer scheme
+  drag_coefficient         =                  1.0E+0 ! Drag coefficient of the
+                                                     ! blocked-layer scheme
+  nwm                      =                       1 ! Number of initial wave
+                                                     ! modes
+  zmin_wkb_dim             =                  0.0E+0 ! Minimum altitude for
+                                                     ! wave-mean-flow
+                                                     ! interaction
+  nray_fac                 =                       4 ! Maximum multiplication
+                                                     ! factor per spectral
+                                                     ! dimension
+  cons_merge               =                    'wa' ! Conserved quantity in
+                                                     ! ray-volume merging ('wa'
+                                                     ! = wave action, 'en' =
+                                                     ! wave energy)
 &end
 
 &bubble
-dTheta0_dim              =                  6.0E+0 ! ...
-xRadius_dim              =                  4.0E+3 ! ...
-zRadius_dim              =                  2.0E+3 ! ...
-xCenter_dim              =                  0.0E+0 ! ...
-yCenter_dim              =                  2.0E+4 ! ...
-zCenter_dim              =                  3.0E+3 ! ...
-zExcentricity            =                  1.0E+0 ! ...
-rhoCenter_dim            =                  1.0E+3 ! ...
+  dTheta0_dim              =                  6.0E+0 ! ...
+  xRadius_dim              =                  4.0E+3 ! ...
+  zRadius_dim              =                  2.0E+3 ! ...
+  xCenter_dim              =                  0.0E+0 ! ...
+  yCenter_dim              =                  2.0E+4 ! ...
+  zCenter_dim              =                  3.0E+3 ! ...
+  zExcentricity            =                  1.0E+0 ! ...
+  rhoCenter_dim            =                  1.0E+3 ! ...
 &end
 
 &robert_bubble
-dTheta1_dim              =                  5.0E-1 ! Potential temperature
-                                                   ! offset
-a1_dim                   =                  1.5E+2 ! Radius of plateau
-sigma1_dim               =                  5.0E+1 ! Gaussian edge profile
-xCenter1_dim             =                  0.0E+0 ! ...
-zCenter1_dim             =                  3.0E+2 ! ...
-dTheta2_dim              =                 -1.5E-1 ! ...
-a2_dim                   =                  0.0E+0 ! ...
-sigma2_dim               =                  5.0E+1 ! ...
-xCenter2_dim             =                  6.0E+1 ! ...
-zCenter2_dim             =                  6.4E+2 ! ...
+  dTheta1_dim              =                  5.0E-1 ! Potential temperature
+                                                     ! offset
+  a1_dim                   =                  1.5E+2 ! Radius of plateau
+  sigma1_dim               =                  5.0E+1 ! Gaussian edge profile
+  xCenter1_dim             =                  0.0E+0 ! ...
+  zCenter1_dim             =                  3.0E+2 ! ...
+  dTheta2_dim              =                 -1.5E-1 ! ...
+  a2_dim                   =                  0.0E+0 ! ...
+  sigma2_dim               =                  5.0E+1 ! ...
+  xCenter2_dim             =                  6.0E+1 ! ...
+  zCenter2_dim             =                  6.4E+2 ! ...
 &end
 
 &mountainwavelist
-u_relax                  =                  1.0E+1 ! Zonal relaxation wind
-v_relax                  =                  0.0E+0 ! Meridional relaxation
-                                                   ! wind
-w_relax                  =                  0.0E+0 ! Vertical relaxation wind
-t_relax                  =                  5.0E+3 ! Relaxation time
-t_ramp                   =                  2.5E+3 ! Not used at the moment
-xextent_relax            =                 1.0E+10 ! Zonal extent of
-                                                   ! relaxation region
-yextent_relax            =                  0.0E+0 ! Meridional extent of
-                                                   ! relaxation region
-wind_relaxation          =                       F ! Relaxation switch
-surface_layer_depth      =                  0.0E+0 ! Surface-layer depth
+  u_relax                  =                  1.0E+1 ! Zonal relaxation wind
+  v_relax                  =                  0.0E+0 ! Meridional relaxation
+                                                     ! wind
+  w_relax                  =                  0.0E+0 ! Vertical relaxation wind
+  t_relax                  =                  5.0E+3 ! Relaxation time
+  t_ramp                   =                  2.5E+3 ! Not used at the moment
+  xextent_relax            =                 1.0E+10 ! Zonal extent of
+                                                     ! relaxation region
+  yextent_relax            =                  0.0E+0 ! Meridional extent of
+                                                     ! relaxation region
+  wind_relaxation          =                       F ! Relaxation switch
+  surface_layer_depth      =                  0.0E+0 ! Surface-layer depth
 &end
 
 &baroclinic_LC
-zero_initial_state       =                       F ! ...
-z_trpp0_dim              =                  8.0E+3 ! Mean tropopause height
-z_baro_dim               =                  2.4E+4 ! Altitude above which the
-                                                   ! atmosphere is barotropic
-thet0_dim                =                 2.73E+2 ! Characteristic potential
-                                                   ! temperature
-ntrp_dim                 =                  1.0E-2 ! Buoyancy frequency of
-                                                   ! the troposphere
-nstr_dim                 =                 2.45E-2 ! Buoyancy frequency of
-                                                   ! the stratosphere
-jwdth_dim                =                  2.4E+6 ! Jet half width
-kaptpp                   =                  7.0E+1 ! Jet slope
-add_ptptb                =                       T ! Add local potential-
-                                                   ! temperature perturbation
-ptptb_x_dim              =                  2.5E+6 ! Location in x of local
-                                                   ! potential-temperature
-                                                   ! perturbation
-ptptb_y_dim              =                  5.0E+6 ! Location in y of local
-                                                   ! potential-temperature
-                                                   ! perturbation
-ptptb_z_dim              =                  9.0E+3 ! Location in z of local
-                                                   ! potential-temperature
-                                                   ! perturbation
-ptptb_dh_dim             =                  8.0E+5 ! Horizontal width of
-                                                   ! local potential-
-                                                   ! temperature perturbation
-ptptb_dz_dim             =                  2.0E+3 ! Vertical width of local
-                                                   ! potential-temperature
-                                                   ! perturbation
-ptptb_amp_dim            =                  3.0E+0 ! Amplitude of local
-                                                   ! potential-temperature
-                                                   ! perturbation
-add_noise                =                       F ! Add noise to the initial
-                                                   ! potential temperature
-proc_noise               =                  1.0E-2 ! Relative amplitude of
-                                                   ! potential-temperature
-                                                   ! noise
-tau_relax                =                 8.64E+5 ! ...
-tau_relax_low            =                 8.64E+5 ! ...
-sigma_tau                =                  2.0E-2 ! Relative thickness of
-                                                   ! relaxation profile
-tau_jet                  =                  7.2E+3 ! Time for jet formation
-Sponge_Rel_Bal_Type      =                   'env' ! Relaxation state: 'hyd'
-                                                   ! = hydrostatic balance,
-                                                   ! 'env' = geostrophic
-                                                   ! balance
-ta_hs_dim                =                3.456E+6 ! Thermal-relaxation time
-                                                   ! scale outside tropical
-                                                   ! boundary layer (zero
-                                                   ! means infinity)
-ts_hs_dim                =                3.456E+5 ! Thermal-relaxation time
-                                                   ! scale in tropical
-                                                   ! boundary layer (zero
-                                                   ! means infinity)
-tf_hs_dim                =                 8.64E+4 ! Boundary-layer Rayleigh-
-                                                   ! damping  time scale
-sigb_hs                  =                  7.0E-1 ! Sigma of boundary-layer
-                                                   ! top
+  zero_initial_state       =                       F ! ...
+  z_trpp0_dim              =                  8.0E+3 ! Mean tropopause height
+  z_baro_dim               =                  2.4E+4 ! Altitude above which the
+                                                     ! atmosphere is barotropic
+  thet0_dim                =                 2.73E+2 ! Characteristic potential
+                                                     ! temperature
+  ntrp_dim                 =                  1.0E-2 ! Buoyancy frequency of
+                                                     ! the troposphere
+  nstr_dim                 =                 2.45E-2 ! Buoyancy frequency of
+                                                     ! the stratosphere
+  jwdth_dim                =                  2.4E+6 ! Jet half width
+  kaptpp                   =                  7.0E+1 ! Jet slope
+  add_ptptb                =                       T ! Add local potential-
+                                                     ! temperature perturbation
+  ptptb_x_dim              =                  2.5E+6 ! Location in x of local
+                                                     ! potential-temperature
+                                                     ! perturbation
+  ptptb_y_dim              =                  5.0E+6 ! Location in y of local
+                                                     ! potential-temperature
+                                                     ! perturbation
+  ptptb_z_dim              =                  9.0E+3 ! Location in z of local
+                                                     ! potential-temperature
+                                                     ! perturbation
+  ptptb_dh_dim             =                  8.0E+5 ! Horizontal width of
+                                                     ! local potential-
+                                                     ! temperature perturbation
+  ptptb_dz_dim             =                  2.0E+3 ! Vertical width of local
+                                                     ! potential-temperature
+                                                     ! perturbation
+  ptptb_amp_dim            =                  3.0E+0 ! Amplitude of local
+                                                     ! potential-temperature
+                                                     ! perturbation
+  add_noise                =                       F ! Add noise to the initial
+                                                     ! potential temperature
+  proc_noise               =                  1.0E-2 ! Relative amplitude of
+                                                     ! potential-temperature
+                                                     ! noise
+  tau_relax                =                 8.64E+5 ! ...
+  tau_relax_low            =                 8.64E+5 ! ...
+  sigma_tau                =                  2.0E-2 ! Relative thickness of
+                                                     ! relaxation profile
+  tau_jet                  =                  7.2E+3 ! Time for jet formation
+  Sponge_Rel_Bal_Type      =                   'env' ! Relaxation state: 'hyd'
+                                                     ! = hydrostatic balance,
+                                                     ! 'env' = geostrophic
+                                                     ! balance
+  ta_hs_dim                =                3.456E+6 ! Thermal-relaxation time
+                                                     ! scale outside tropical
+                                                     ! boundary layer (zero
+                                                     ! means infinity)
+  ts_hs_dim                =                3.456E+5 ! Thermal-relaxation time
+                                                     ! scale in tropical
+                                                     ! boundary layer (zero
+                                                     ! means infinity)
+  tf_hs_dim                =                 8.64E+4 ! Boundary-layer Rayleigh-
+                                                     ! damping  time scale
+  sigb_hs                  =                  7.0E-1 ! Sigma of boundary-layer
+                                                     ! top
 &end
 
 &baroclinic_ID
-bar_sigma_y              =                  1.0E-1 ! ...
-u_strength               =                  3.0E+1 ! Jet strength
-dTh_atm                  =                  2.0E+1 ! Potential-temperature
-                                                   ! difference between poles
-                                                   ! and tropics
-init_2Dto3D              =                       F ! Initialize 3D state from
-                                                   ! 2D balanced state
-init_bal                 =             'geostr_id' ! ...
-lastrecordnum            =                      88 ! Last record in 2D output
-fileinitstate2D          =    'pf_all_2D3D_in.dat' ! File name with 2D
-                                                   ! balanced state
-output_theta_bgr         =                       F ! Output environmental
-                                                   ! potential temperature
-output_br_vais_sq        =                       T ! Output environmental
-                                                   ! squared buoyancy
-                                                   ! frequency
-output_heat              =                       T ! ...
-balance_eq               =                 'PI_an' ! ...
-output_rho_bgr           =                       T ! Output environmental
-                                                   ! density
+  bar_sigma_y              =                  1.0E-1 ! ...
+  u_strength               =                  3.0E+1 ! Jet strength
+  dTh_atm                  =                  2.0E+1 ! Potential-temperature
+                                                     ! difference between poles
+                                                     ! and tropics
+  init_2Dto3D              =                       F ! Initialize 3D state from
+                                                     ! 2D balanced state
+  init_bal                 =             'geostr_id' ! ...
+  lastrecordnum            =                      88 ! Last record in 2D output
+  fileinitstate2D          =    'pf_all_2D3D_in.dat' ! File name with 2D
+                                                     ! balanced state
+  output_theta_bgr         =                       F ! Output environmental
+                                                     ! potential temperature
+  output_br_vais_sq        =                       T ! Output environmental
+                                                     ! squared buoyancy
+                                                     ! frequency
+  output_heat              =                       T ! ...
+  balance_eq               =                 'PI_an' ! ...
+  output_rho_bgr           =                       T ! Output environmental
+                                                     ! density
 &end
 
 &modelList
-model                    = 'pseudo_incompressible' ! Dynamic equations
-vert_theta               =                  9.0E+1 ! Rotation about x
-vert_alpha               =                  0.0E+0 ! Rotation about y
+  model                    = 'pseudo_incompressible' ! Dynamic equations
+  vert_theta               =                  9.0E+1 ! Rotation about x
+  vert_alpha               =                  0.0E+0 ! Rotation about y
 &end
 
 &solverList
-cfl                      =                  5.0E-1 ! CFL number
-cfl_wave                 =                  5.0E-1 ! WKB CFL number
-dtMax_dim                =                  6.0E+1 ! Maximum time step
-tStepChoice              =                   'cfl' ! 'fix' or 'cfl'
-timeScheme               =          'semiimplicit' ! 'LS_Will_RK3' or
-                                                   ! 'semiimplicit'
-auxil_equ                =                       F ! Buoyancy equation
-limiterType1             =             'MCVariant' ! 'minmod', 'MCVariant' or
-                                                   ! 'Cada'
-TurbScheme               =                       F ! Turbulence scheme
-turb_dts                 =                  5.0E+3 ! Turbulent damping time
-DySmaScheme              =                       F ! Dynamic Smagorinsky
-                                                   ! scheme
-dtWave_on                =                       T ! Limit time step by
-                                                   ! inverse buoyancy
-                                                   ! frequency
-heatingONK14             =                       F ! Heating as in O'Neill
-                                                   ! and Klein (2014)
-dens_relax               =                       F ! Heating by density
-                                                   ! relaxation
-shap_dts_fac             =                 -1.0E+0 ! Shapiro-filter damping
-                                                   ! time
-n_shap                   =                       4 ! Order of Shapiro filter
+  cfl                      =                  5.0E-1 ! CFL number
+  cfl_wave                 =                  5.0E-1 ! WKB CFL number
+  dtMax_dim                =                  6.0E+1 ! Maximum time step
+  tStepChoice              =                   'cfl' ! 'fix' or 'cfl'
+  timeScheme               =          'semiimplicit' ! 'LS_Will_RK3' or
+                                                     ! 'semiimplicit'
+  auxil_equ                =                       F ! Buoyancy equation
+  limiterType1             =             'MCVariant' ! 'minmod', 'MCVariant' or
+                                                     ! 'Cada'
+  TurbScheme               =                       F ! Turbulence scheme
+  turb_dts                 =                  5.0E+3 ! Turbulent damping time
+  DySmaScheme              =                       F ! Dynamic Smagorinsky
+                                                     ! scheme
+  dtWave_on                =                       T ! Limit time step by
+                                                     ! inverse buoyancy
+                                                     ! frequency
+  heatingONK14             =                       F ! Heating as in O'Neill
+                                                     ! and Klein (2014)
+  dens_relax               =                       F ! Heating by density
+                                                     ! relaxation
+  shap_dts_fac             =                 -1.0E+0 ! Shapiro-filter damping
+                                                     ! time
+  n_shap                   =                       4 ! Order of Shapiro filter
 &end
 
 &poissonSolverList
-tolPoisson               =                  1.0E-8 ! Abort criterion
-abs_tol                  =                  0.0E+0 ! Lower bound for tolerance
-tolCond                  =                 1.0E-23 ! Preconditioner tolerance
-maxIterPoisson           =                    1000 ! Maximum iterations
-preconditioner           =                   'yes' ! 'no' or 'yes'
-dtau                     =                  4.0E+0 ! Time parameter for
-                                                   ! preconditioner
-maxIterADI               =                       2 ! Preconditioner iterations
-initialCleaning          =                       T ! Enforce initial non-
-                                                   ! divergence
-correctMomentum          =                       T ! Correct momentum so that
-                                                   ! divergence constraint is
-                                                   ! fulfilled
-correctDivError          =                       F ! Subtract divergence
-tolcrit                  =                   'abs' ! 'abs' or 'rel'
+  tolPoisson               =                  1.0E-8 ! Abort criterion
+  abs_tol                  =                  0.0E+0 ! Lower bound for tolerance
+  tolCond                  =                 1.0E-23 ! Preconditioner tolerance
+  maxIterPoisson           =                    1000 ! Maximum iterations
+  preconditioner           =                   'yes' ! 'no' or 'yes'
+  dtau                     =                  4.0E+0 ! Time parameter for
+                                                     ! preconditioner
+  maxIterADI               =                       2 ! Preconditioner iterations
+  initialCleaning          =                       T ! Enforce initial non-
+                                                     ! divergence
+  correctMomentum          =                       T ! Correct momentum so that
+                                                     ! divergence constraint is
+                                                     ! fulfilled
+  correctDivError          =                       F ! Subtract divergence
+  tolcrit                  =                   'abs' ! 'abs' or 'rel'
 &end
 
 &atmosphereList
-referenceQuantities      =                 'Klein' ! 'Klein', 'WKB', 'SI' or
-                                                   ! 'general'
-specifyReynolds          =                       F ! Use inverse Reynolds
-                                                   ! number
-ReInv                    =                  0.0E+0 ! Inverse Reynolds number
-mu_viscous_dim           =                  0.0E+0 ! Kinematic viscosity
-mu_conduct_dim           =                  0.0E+0 ! Heat conductivity
-background               =              'isothermal' ! 'realistic',
-                                                   ! 'isothermal',
-                                                   ! 'isentropic', 'const-N',
-                                                   ! 'diflapse' or
-                                                   ! 'HeldSuarez'
-N_BruntVaisala_dim       =                  1.0E-2 ! Buoyancy frequency for
-                                                   ! 'const-N'
-theta0_dim               =                  3.0E+2 ! Background potential
-                                                   ! temperature for
-                                                   ! 'isentropic'
-Temp0_dim                =                  3.0E+2 ! Background temperature
-                                                   ! for 'isothermal'
-press0_dim               =                  1.0E+5 ! Ground pressure
-backgroundFlow_dim(1)    =                  1.0E+1 ! Initial wind
-backgroundFlow_dim(2)    =                  0.0E+0 ! Initial wind
-backgroundFlow_dim(3)    =                  0.0E+0 ! Initial wind
-f_Coriolis_dim           =                  0.0E+0 ! Coriolis frequency
-corset                   =              'constant' ! 'constant' or 'periodic'
-z_tr_dim                 =                  1.2E+4 ! Tropopause height
-theta_tr_dim             =                  3.0E+2 ! Potential temperature in
-                                                   ! troposphere
-gamma_t                  =                  0.0E+0 ! Lapse rate in troposphere
-gamma_s                  =                  0.0E+0 ! Lapse rate in
-                                                   ! stratosphere
-tp_strato_dim            =                  2.0E+2 ! Temperature in
-                                                   ! stratosphere for
-                                                   ! 'HeldSuarez'
-tp_srf_trp_dim           =                 3.15E+2 ! Tropical surface
-                                                   ! temperature for
-                                                   ! 'HeldSuarez'
-tpdiffhor_tropo_dim      =                  6.0E+1 ! Temperature difference
-                                                   ! between poles and
-                                                   ! tropics for 'HeldSuarez'
-ptdiffvert_tropo_dim     =                  1.0E+1 ! Vertical potential
-                                                   ! temperature difference
-                                                   ! in troposphere for
-                                                   ! 'HeldSuarez'
+  referenceQuantities      =                 'Klein' ! 'Klein', 'WKB', 'SI' or
+                                                     ! 'general'
+  specifyReynolds          =                       F ! Use inverse Reynolds
+                                                     ! number
+  ReInv                    =                  0.0E+0 ! Inverse Reynolds number
+  mu_viscous_dim           =                  0.0E+0 ! Kinematic viscosity
+  mu_conduct_dim           =                  0.0E+0 ! Heat conductivity
+  background               =            'isothermal' ! 'realistic',
+                                                     ! 'isothermal',
+                                                     ! 'isentropic', 'const-N',
+                                                     ! 'diflapse' or
+                                                     ! 'HeldSuarez'
+  N_BruntVaisala_dim       =                  1.0E-2 ! Buoyancy frequency for
+                                                     ! 'const-N'
+  theta0_dim               =                  3.0E+2 ! Background potential
+                                                     ! temperature for
+                                                     ! 'isentropic'
+  Temp0_dim                =                  3.0E+2 ! Background temperature
+                                                     ! for 'isothermal'
+  press0_dim               =                  1.0E+5 ! Ground pressure
+  backgroundFlow_dim(1)    =                  1.0E+1 ! Initial wind
+  backgroundFlow_dim(2)    =                  0.0E+0 ! Initial wind
+  backgroundFlow_dim(3)    =                  0.0E+0 ! Initial wind
+  f_Coriolis_dim           =                  0.0E+0 ! Coriolis frequency
+  corset                   =              'constant' ! 'constant' or 'periodic'
+  z_tr_dim                 =                  1.2E+4 ! Tropopause height
+  theta_tr_dim             =                  3.0E+2 ! Potential temperature in
+                                                     ! troposphere
+  gamma_t                  =                  0.0E+0 ! Lapse rate in troposphere
+  gamma_s                  =                  0.0E+0 ! Lapse rate in
+                                                     ! stratosphere
+  tp_strato_dim            =                  2.0E+2 ! Temperature in
+                                                     ! stratosphere for
+                                                     ! 'HeldSuarez'
+  tp_srf_trp_dim           =                 3.15E+2 ! Tropical surface
+                                                     ! temperature for
+                                                     ! 'HeldSuarez'
+  tpdiffhor_tropo_dim      =                  6.0E+1 ! Temperature difference
+                                                     ! between poles and
+                                                     ! tropics for 'HeldSuarez'
+  ptdiffvert_tropo_dim     =                  1.0E+1 ! Vertical potential
+                                                     ! temperature difference
+                                                     ! in troposphere for
+                                                     ! 'HeldSuarez'
 &end
 
 &topographyList
-topography               =                       T ! Terrain-following
-                                                   ! coordinates
-ipolTFC                  =                       2 ! Interpolation in the
-                                                   ! transformation of w
-topographyTime           =                  0.0E+0 ! Topography growth time
-mountainHeight_dim       =                  1.5E+2 ! Maximum height
-mountainWidth_dim        =                  5.0E+3 ! Half width
-mountain_case            =                      13 ! Predefined topography
-height_factor            =                  2.0E+0 ! Ratio between large- and
-                                                   ! small-scale wave
-                                                   ! amplitudes
-width_factor             =                  1.0E+1 ! Ratio between large- and
-                                                   ! small-scale wavelengths
-spectral_modes           =                       1 ! Number of spectral modes
-stretch_exponent         =                  1.0E+0 ! Exponent of vertical
-                                                   ! grid stretching (1 for
-                                                   ! no stretching)
+  topography               =                       T ! Terrain-following
+                                                     ! coordinates
+  ipolTFC                  =                       2 ! Interpolation in the
+                                                     ! transformation of w
+  topographyTime           =                  0.0E+0 ! Topography growth time
+  mountainHeight_dim       =                  1.5E+2 ! Maximum height
+  mountainWidth_dim        =                  5.0E+3 ! Half width
+  mountain_case            =                      13 ! Predefined topography
+  height_factor            =                  2.0E+0 ! Ratio between large- and
+                                                     ! small-scale wave
+                                                     ! amplitudes
+  width_factor             =                  1.0E+1 ! Ratio between large- and
+                                                     ! small-scale wavelengths
+  spectral_modes           =                       1 ! Number of spectral modes
+  stretch_exponent         =                  1.0E+0 ! Exponent of vertical
+                                                     ! grid stretching (1 for
+                                                     ! no stretching)
 &end
 
 &boundaryList
-rhoFluxCorr              =                       F ! ...
-iceFluxCorr              =                       F ! ...
-uFluxCorr                =                       F ! ...
-vFluxCorr                =                       F ! ...
-wFluxCorr                =                       F ! ...
-thetaFluxCorr            =                       F ! ...
-nbCellCorr               =                       1 ! ...
-spongeLayer              =                       T ! General sponge layer
-                                                   ! switch
-sponge_uv                =                       F ! Sponge layer for
-                                                   ! horizontal wind if
-                                                   ! unifiedSponge = .false.
-spongeHeight             =                  1.0E-1 ! Relative height of lower
-                                                   ! sponge layer edge (scale
-                                                   ! height for unifiedSponge
-                                                   ! = .true. and spongeType
-                                                   ! = 'exponential')
-spongeAlphaZ_dim         =                 1.79E-2 ! Maximum relaxation rate
-                                                   ! for unifiedSponge =
-                                                   ! .true.
-spongeAlphaZ_fac         =                  1.0E+0 ! Sponge layer factor for
-                                                   ! unifiedSponge = .false.
-unifiedSponge            =                       T ! Unified sponge for both
-                                                   ! time schemes, applied to
-                                                   ! wind and density
-lateralSponge            =                       T ! Lateral sponge for
-                                                   ! unifiedSponge = .true.
-spongeType               =            'exponential' ! Sponge layer profile for
-                                                   ! unifiedSponge = .true.
-spongeOrder              =                       1 ! Order of polynomial
-                                                   ! sponge
-cosmoSteps               =                       1 ! Relative strength of
-                                                   ! COSMO sponge
-relax_to_mean            =                       F ! Relax the wind to its
-                                                   ! (terrain-following)
-                                                   ! horizontal mean
-                                                   ! (otherwise, relax to the
-                                                   ! initial state) if
-                                                   ! unifiedSponge == .true.
-relaxation_period        =                  0.0E+0 ! Period of an oscillation
-                                                   ! superposed on the
-                                                   ! background wind if
-                                                   ! unifiedSponge == .true.
-                                                   ! and relax_to_mean ==
-                                                   ! .false. (0 for no
-                                                   ! oscillation)
-relaxation_amplitude     =                  0.0E+0 ! Relative amplitude of an
-                                                   ! oscillation superposed
-                                                   ! on the background wind
-                                                   ! if unifiedSponge ==
-                                                   ! .true. and relax_to_mean
-                                                   ! == .false.
-xBoundary                =              'periodic' ! Boundary conditions in x
-                                                   ! ('periodic' only)
-yBoundary                =              'periodic' ! Boundary conditions in y
-                                                   ! ('periodic' only)
-zBoundary                =            'solid_wall' ! Boundary conditions in z
-                                                   ! ('periodic' or
-                                                   ! 'solid_wall')
+  rhoFluxCorr              =                       F ! ...
+  iceFluxCorr              =                       F ! ...
+  uFluxCorr                =                       F ! ...
+  vFluxCorr                =                       F ! ...
+  wFluxCorr                =                       F ! ...
+  thetaFluxCorr            =                       F ! ...
+  nbCellCorr               =                       1 ! ...
+  spongeLayer              =                       T ! General sponge layer
+                                                     ! switch
+  sponge_uv                =                       F ! Sponge layer for
+                                                     ! horizontal wind if
+                                                     ! unifiedSponge = .false.
+  spongeHeight             =                  1.0E-1 ! Relative height of lower
+                                                     ! sponge layer edge (scale
+                                                     ! height for unifiedSponge
+                                                     ! = .true. and spongeType
+                                                     ! = 'exponential')
+  spongeAlphaZ_dim         =                 1.79E-2 ! Maximum relaxation rate
+                                                     ! for unifiedSponge =
+                                                     ! .true.
+  spongeAlphaZ_fac         =                  1.0E+0 ! Sponge layer factor for
+                                                     ! unifiedSponge = .false.
+  unifiedSponge            =                       T ! Unified sponge for both
+                                                     ! time schemes, applied to
+                                                     ! wind and density
+  lateralSponge            =                       T ! Lateral sponge for
+                                                     ! unifiedSponge = .true.
+  spongeType               =           'exponential' ! Sponge layer profile for
+                                                     ! unifiedSponge = .true.
+  spongeOrder              =                       1 ! Order of polynomial
+                                                     ! sponge
+  cosmoSteps               =                       1 ! Relative strength of
+                                                     ! COSMO sponge
+  relax_to_mean            =                       F ! Relax the wind to its
+                                                     ! (terrain-following)
+                                                     ! horizontal mean
+                                                     ! (otherwise, relax to the
+                                                     ! initial state) if
+                                                     ! unifiedSponge == .true.
+  relaxation_period        =                  0.0E+0 ! Period of an oscillation
+                                                     ! superposed on the
+                                                     ! background wind if
+                                                     ! unifiedSponge == .true.
+                                                     ! and relax_to_mean ==
+                                                     ! .false. (0 for no
+                                                     ! oscillation)
+  relaxation_amplitude     =                  0.0E+0 ! Relative amplitude of an
+                                                     ! oscillation superposed
+                                                     ! on the background wind
+                                                     ! if unifiedSponge ==
+                                                     ! .true. and relax_to_mean
+                                                     ! == .false.
+  relaxation_wind(1)       =                  1.0E+1 ! Wind to be obtained via
+                                                     ! relaxation if
+                                                     ! relax_to_mean == .false.
+  relaxation_wind(2)       =                  0.0E+0 ! Wind to be obtained via
+                                                     ! relaxation if
+                                                     ! relax_to_mean == .false.
+  relaxation_wind(3)       =                  0.0E+0 ! Wind to be obtained via
+                                                     ! relaxation if
+                                                     ! relax_to_mean == .false.
+  xBoundary                =              'periodic' ! Boundary conditions in x
+                                                     ! ('periodic' only)
+  yBoundary                =              'periodic' ! Boundary conditions in y
+                                                     ! ('periodic' only)
+  zBoundary                =            'solid_wall' ! Boundary conditions in z
+                                                     ! ('periodic' or
+                                                     ! 'solid_wall')
 &end
 
 &wkbList
-rayTracer                =                       T ! Ray-tracer switch
+  rayTracer                =                       T ! Ray-tracer switch
 &end
 
 &tracerList
-tracerSetup              =               'alpha_z' ! initial tracer
-                                                   ! distribution
-include_trfrc_lo         =                       T ! leading-order GW tracer
-                                                   ! forcing
-include_trfrc_no         =                       T ! next-order GW tracer
-                                                   ! forcing
-include_trfrc_mix        =                       T ! diffusive tracer mixing
+  tracerSetup              =               'alpha_z' ! initial tracer
+                                                     ! distribution
+  include_trfrc_lo         =                       T ! leading-order GW tracer
+                                                     ! forcing
+  include_trfrc_no         =                       T ! next-order GW tracer
+                                                     ! forcing
+  include_trfrc_mix        =                       T ! diffusive tracer mixing
 &end
 
 &iceList
-inN                      =                       0 ! ...
-inQ                      =                       0 ! ...
-inQv                     =                       0 ! ...
-nVarIce                  =                       0 ! ...
-dt_ice                   =                  0.0E+0 ! ...
-no_ice_source            =                       F ! ...
+  inN                      =                       0 ! Ice number concentration
+  inQ                      =                       0 ! Ice mixing ratio
+  inQv                     =                       0 ! Vapor mixing ratio
+  nVarIce                  =                       0 ! Number ice variables
+  dt_ice                   =                  0.0E+0 ! Time step ice
+                                                     ! microphysics
+  no_ice_source            =                       F ! Switch off ice
+                                                     ! microphysics, only
+                                                     ! advect
+  parameterized_nucleation =                       F ! Param. or resolved
+                                                     ! nucleation source term
+  compute_cloudcover       =                       F ! Compute ice physics on a
+                                                     ! sub-grid within PinCFlow
+                                                     ! grid
+  nscx                     =                       1 ! sub-grid points in x per
+                                                     ! cell
+  nscx                     =                       1 ! sub-grid points in y per
+                                                     ! cell
+&end
+
+&case_wkb_5_list
+  Wavepacket number        =                       1 ! List below parameters of
+                                                     ! wavepacket
+  branchr_sp               =                       0 ! Frequency branches
+  amp_wkb                  =                  0.0E+0 ! Relative amplitude of
+                                                     ! wave packet
+  wlrx_init_sp             =                  0.0E+0 ! Wavelength in x of wave
+                                                     ! packets
+  wlry_init                =                  0.0E+0 ! Wavelength in y of wave
+                                                     ! packet
+  wlrz_init                =                  0.0E+0 ! Wavelength in z of wave
+                                                     ! packet
+  xr0_dim                  =                  0.0E+0 ! Wave packet center in x
+  yr0_dim                  =                  0.0E+0 ! Wave packet center in y
+  zr0_dim                  =                  0.0E+0 ! Wave packet center in z
+  sigwpx_dim               =                  0.0E+0 ! Wave packet width in x
+                                                     ! (0.0 for infinite width)
+  sigwpy_dim               =                  0.0E+0 ! Wave packet width in y
+                                                     ! (0.0 for infinite width)
+  sigwpz_dim               =                  0.0E+0 ! Wave packet width in z
+                                                     ! (0.0 for infinite width)
+  Wavepacket number        =                       2 ! List below parameters of
+                                                     ! wavepacket
+  branchr_sp               =                       0 ! Frequency branches
+  amp_wkb                  =                  0.0E+0 ! Relative amplitude of
+                                                     ! wave packet
+  wlrx_init_sp             =                  0.0E+0 ! Wavelength in x of wave
+                                                     ! packets
+  wlry_init                =                  0.0E+0 ! Wavelength in y of wave
+                                                     ! packet
+  wlrz_init                =                  0.0E+0 ! Wavelength in z of wave
+                                                     ! packet
+  xr0_dim                  =                  0.0E+0 ! Wave packet center in x
+  yr0_dim                  =                  0.0E+0 ! Wave packet center in y
+  zr0_dim                  =                  0.0E+0 ! Wave packet center in z
+  sigwpx_dim               =                  0.0E+0 ! Wave packet width in x
+                                                     ! (0.0 for infinite width)
+  sigwpy_dim               =                  0.0E+0 ! Wave packet width in y
+                                                     ! (0.0 for infinite width)
+  sigwpz_dim               =                  0.0E+0 ! Wave packet width in z
+                                                     ! (0.0 for infinite width)
+&end
+
+&MultipleWavePackets_list
+  Wavepacket number        =                       1 ! List below parameters of
+                                                     ! wavepacket
+  lambdaX_dim              =                  0.0E+0 ! Wavelength in x (0.0 for
+                                                     ! infinite wavelength)
+  lambdaY_dim              =                  0.0E+0 ! Wavelength in y (0.0 for
+                                                     ! infinite wavelength)
+  lambdaZ_dim              =                  0.0E+0 ! Wavelength in z
+  amplitudeFactor          =                  0.0E+0 ! Normalized buoyancy
+                                                     ! amplitude
+  x0_dim                   =                  0.0E+0 ! Wave-packet center in x
+  y0_dim                   =                  0.0E+0 ! Wave-packet center in y
+  z0_dim                   =                  0.0E+0 ! Wave-packet center in z
+  sigma_dim                =                  0.0E+0 ! Vertical width of
+                                                     ! Gaussian wave packet
+  sigma_hor_dim            =                  0.0E+0 ! Cosine distribution
+                                                     ! width in x (0.0 for
+                                                     ! infinite width)
+  amp_mod_x                =                  1.0E+0 ! Fractional amplitude
+                                                     ! modulation in x
+  sigma_hor_yyy_dim        =                  0.0E+0 ! Cosine distribution
+                                                     ! width in y (0.0 for
+                                                     ! infinite width)
+  omiSign                  =                       0 ! Frequency branch
+  Wavepacket number        =                       2 ! List below parameters of
+                                                     ! wavepacket
+  lambdaX_dim              =                  0.0E+0 ! Wavelength in x (0.0 for
+                                                     ! infinite wavelength)
+  lambdaY_dim              =                  0.0E+0 ! Wavelength in y (0.0 for
+                                                     ! infinite wavelength)
+  lambdaZ_dim              =                  0.0E+0 ! Wavelength in z
+  amplitudeFactor          =                  0.0E+0 ! Normalized buoyancy
+                                                     ! amplitude
+  x0_dim                   =                  0.0E+0 ! Wave-packet center in x
+  y0_dim                   =                  0.0E+0 ! Wave-packet center in y
+  z0_dim                   =                  0.0E+0 ! Wave-packet center in z
+  sigma_dim                =                  0.0E+0 ! Vertical width of
+                                                     ! Gaussian wave packet
+  sigma_hor_dim            =                  0.0E+0 ! Cosine distribution
+                                                     ! width in x (0.0 for
+                                                     ! infinite width)
+  amp_mod_x                =                  1.0E+0 ! Fractional amplitude
+                                                     ! modulation in x
+  sigma_hor_yyy_dim        =                  0.0E+0 ! Cosine distribution
+                                                     ! width in y (0.0 for
+                                                     ! infinite width)
+  omiSign                  =                       0 ! Frequency branch
 &end


### PR DESCRIPTION
In GitLab, by Felix Jochum on 2025-07-07

This is a relatively small merge that fixes a few minor issues:

1. Horizontal boundary conditions for the lateral sponge are now properly enforced - this is important for its interpolation to ray-volume positions.
2. The vertical index bounds that are used in the interpolation to ray-volume positions have been improved and unified.
3. The algorithms used for vertical shifting and ray-volume removal have been improved. They cannot affect the launch layer anymore.
4. The launch algorithm "scale" has been removed (it didn't work properly).
5. #25 has been fixed.
6. The ray-volume test loop in `shift_rayvol` has been improved.

On top of that, the namelist parameter `relaxation_wind` has been added, for specification of the wind to be obtained by relaxation if `(spongeLayer .and. unifiedSponge .and. .not. relax_to_mean)`. Also, the variable `small` has been replaced by the machine epsilon for double precision in `timstep`.