### PR TITLE
Customizable safety checks in get_next_half_level and get_next_level.

### DIFF
--- a/src/MSGWaM/Interpolation/get_next_half_level.jl
+++ b/src/MSGWaM/Interpolation/get_next_half_level.jl
@@ -4,7 +4,9 @@ get_next_half_level(
     i::Integer,
     j::Integer,
     z::AbstractFloat,
-    state::State,
+    state::State;
+    dkd::Integer = 0,
+    dku::Integer = 0,
 )::Integer
 ```
 
@@ -12,9 +14,11 @@ Determine and return the index of the next half-level above `z` at the horizonta
 
 This method is heavily used for interpolation to ray-volume positions. To ensure that the vertical boundary conditions are met and no out-of-bounds errors occur, the following constraints are set.
 
-  - In MPI processes at the lower boundary of the domain, the returned index cannot be smaller than `state.domain.k0`, in other processes, it cannot be smaller than 3.
+  - In MPI processes at the lower boundary of the domain, the computed index has the lower bound `state.domain.k0`. In other processes, an error is thrown if it is below `1 + dkd`.
 
-  - In MPI processes at the upper boundary of the domain, the returned index cannot be larger than `state.domain.k1`, in other processes, it cannot be larger than `state.domain.nzz - 1`.
+  - In MPI processes at the upper boundary of the domain, the computed index has the upper bound `state.domain.k1`. In other processes, an error is thrown if it is above `state.domain.nzz - dku`.
+
+In case an error is thrown, the parameter `cfl_wave` of the discretization namelist should be set to a smaller value.
 
 # Arguments
 
@@ -25,6 +29,12 @@ This method is heavily used for interpolation to ray-volume positions. To ensure
   - `z`: Vertical position.
 
   - `state`: Model state.
+
+# Keywords
+
+  - `dkd`: Number of levels needed below.
+
+  - `dku`: Number of levels needed above.
 """
 function get_next_half_level end
 
@@ -32,7 +42,9 @@ function get_next_half_level(
     i::Integer,
     j::Integer,
     z::AbstractFloat,
-    state::State,
+    state::State;
+    dkd::Integer = 0,
+    dku::Integer = 0,
 )::Integer
     (; sizezz, nzz, ko, k0, k1) = state.domain
     (; ztildetfc) = state.grid
@@ -45,21 +57,29 @@ function get_next_half_level(
     if ko == 0
         k = max(k, k0)
     else
-        if k < 3
-            error("Error in get_next_half_level: k = ", k, " < 3")
+        if k < 1 + dkd
+            error(
+                "Error in get_next_half_level: k = ",
+                k,
+                " < ",
+                1 + dkd,
+                " = 1 + dkd",
+                "\nPlease choose a smaller WKB-CFL number.",
+            )
         end
     end
 
     if ko + nzz == sizezz
         k = min(k, k1)
     else
-        if k > nzz - 1
+        if k > nzz - dku
             error(
                 "Error in get_next_half_level: k = ",
                 k,
                 " > ",
-                nzz - 1,
-                " = nzz - 1",
+                nzz - dku,
+                " = nzz - dku",
+                "\nPlease choose a smaller WKB-CFL number.",
             )
         end
     end

--- a/src/MSGWaM/Interpolation/get_next_level.jl
+++ b/src/MSGWaM/Interpolation/get_next_level.jl
@@ -1,15 +1,24 @@
 """
 ```julia
-get_next_level(i::Integer, j::Integer, z::AbstractFloat, state::State)::Integer
+get_next_level(
+    i::Integer,
+    j::Integer,
+    z::AbstractFloat,
+    state::State;
+    dkd::Integer = 0,
+    dku::Integer = 0,
+)::Integer
 ```
 
 Determine and return the index of the next level above `z` at the horizontal position ``\\left(i, j\\right)``.
 
 This method is heavily used for interpolation to ray-volume positions. To ensure that the vertical boundary conditions are met and no out-of-bounds errors occur, the following constraints are set.
 
-  - In MPI processes at the lower boundary of the domain, the returned index cannot be smaller than `state.domain.k0`, in other processes, it cannot be smaller than 3.
+  - In MPI processes at the lower boundary of the domain, the computed index has the lower bound `state.domain.k0`. In other processes, an error is thrown if it is below `1 + dkd`.
 
-  - In MPI processes at the upper boundary of the domain, the returned index cannot be larger than `state.domain.k1 + 1`, in other processes, it cannot be larger than `state.domain.nzz - 1`.
+  - In MPI processes at the upper boundary of the domain, the computed index has the upper bound `state.domain.k1 + 1`. In other processes, an error is thrown if it is above `state.domain.nzz - dku`.
+
+In case an error is thrown, the parameter `cfl_wave` of the discretization namelist should be set to a smaller value.
 
 # Arguments
 
@@ -20,6 +29,12 @@ This method is heavily used for interpolation to ray-volume positions. To ensure
   - `z`: Vertical position.
 
   - `state`: Model state.
+
+# Keywords
+
+  - `dkd`: Number of levels needed below.
+
+  - `dku`: Number of levels needed above.
 """
 function get_next_level end
 
@@ -27,7 +42,9 @@ function get_next_level(
     i::Integer,
     j::Integer,
     z::AbstractFloat,
-    state::State,
+    state::State;
+    dkd::Integer = 0,
+    dku::Integer = 0,
 )::Integer
     (; sizezz, nzz, ko, k0, k1) = state.domain
     (; ztfc) = state.grid
@@ -40,21 +57,29 @@ function get_next_level(
     if ko == 0
         k = max(k, k0)
     else
-        if k < 3
-            error("Error in get_next_level: k = ", k, " < 3")
+        if k < 1 + dkd
+            error(
+                "Error in get_next_level: k = ",
+                k,
+                " < ",
+                1 + dkd,
+                " = 1 + dkd",
+                "\nPlease choose a smaller WKB-CFL number.",
+            )
         end
     end
 
     if ko + nzz == sizezz
         k = min(k, k1 + 1)
     else
-        if k > nzz - 1
+        if k > nzz - dku
             error(
                 "Error in get_next_level: k = ",
                 k,
                 " > ",
-                nzz - 1,
-                " = nzz - 1",
+                nzz - dku,
+                " = nzz - dku",
+                "\nPlease choose a smaller WKB-CFL number.",
             )
         end
     end

--- a/src/MSGWaM/Interpolation/interpolate_mean_flow.jl
+++ b/src/MSGWaM/Interpolation/interpolate_mean_flow.jl
@@ -253,22 +253,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 1)
     klbd = klbu - 1
     @ivy zlbd = (ztfc[il, jb, klbd] + ztfc[il + 1, jb, klbd]) / 2
     @ivy zlbu = (ztfc[il, jb, klbu] + ztfc[il + 1, jb, klbu]) / 2
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 1)
     klfd = klfu - 1
     @ivy zlfd = (ztfc[il, jf, klfd] + ztfc[il + 1, jf, klfd]) / 2
     @ivy zlfu = (ztfc[il, jf, klfu] + ztfc[il + 1, jf, klfu]) / 2
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 1)
     krbd = krbu - 1
     @ivy zrbd = (ztfc[ir, jb, krbd] + ztfc[ir + 1, jb, krbd]) / 2
     @ivy zrbu = (ztfc[ir, jb, krbu] + ztfc[ir + 1, jb, krbu]) / 2
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 1)
     krfd = krfu - 1
     @ivy zrfd = (ztfc[ir, jf, krfd] + ztfc[ir + 1, jf, krfd]) / 2
     @ivy zrfu = (ztfc[ir, jf, krfu] + ztfc[ir + 1, jf, krfu]) / 2
@@ -375,22 +375,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 1)
     klbd = klbu - 1
     @ivy zlbd = (ztfc[il, jb, klbd] + ztfc[il, jb + 1, klbd]) / 2
     @ivy zlbu = (ztfc[il, jb, klbu] + ztfc[il, jb + 1, klbu]) / 2
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 1)
     klfd = klfu - 1
     @ivy zlfd = (ztfc[il, jf, klfd] + ztfc[il, jf + 1, klfd]) / 2
     @ivy zlfu = (ztfc[il, jf, klfu] + ztfc[il, jf + 1, klfu]) / 2
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 1)
     krbd = krbu - 1
     @ivy zrbd = (ztfc[ir, jb, krbd] + ztfc[ir, jb + 1, krbd]) / 2
     @ivy zrbu = (ztfc[ir, jb, krbu] + ztfc[ir, jb + 1, krbu]) / 2
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 1)
     krfd = krfu - 1
     @ivy zrfd = (ztfc[ir, jf, krfd] + ztfc[ir, jf + 1, krfd]) / 2
     @ivy zrfu = (ztfc[ir, jf, krfu] + ztfc[ir, jf + 1, krfu]) / 2
@@ -499,22 +499,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_half_level(il, jb, zlc, state)
+    klbu = get_next_half_level(il, jb, zlc, state; dkd = 1)
     klbd = klbu - 1
     @ivy zlbd = ztildetfc[il, jb, klbd]
     @ivy zlbu = ztildetfc[il, jb, klbu]
 
-    klfu = get_next_half_level(il, jf, zlc, state)
+    klfu = get_next_half_level(il, jf, zlc, state; dkd = 1)
     klfd = klfu - 1
     @ivy zlfd = ztildetfc[il, jf, klfd]
     @ivy zlfu = ztildetfc[il, jf, klfu]
 
-    krbu = get_next_half_level(ir, jb, zlc, state)
+    krbu = get_next_half_level(ir, jb, zlc, state; dkd = 1)
     krbd = krbu - 1
     @ivy zrbd = ztildetfc[ir, jb, krbd]
     @ivy zrbu = ztildetfc[ir, jb, krbu]
 
-    krfu = get_next_half_level(ir, jf, zlc, state)
+    krfu = get_next_half_level(ir, jf, zlc, state; dkd = 1)
     krfd = krfu - 1
     @ivy zrfd = ztildetfc[ir, jf, krfd]
     @ivy zrfu = ztildetfc[ir, jf, krfu]
@@ -657,22 +657,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 2, dku = 1)
     klbd = klbu - 1
     @ivy zlbd = ztfc[il, jb, klbd]
     @ivy zlbu = ztfc[il, jb, klbu]
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 2, dku = 1)
     klfd = klfu - 1
     @ivy zlfd = ztfc[il, jf, klfd]
     @ivy zlfu = ztfc[il, jf, klfu]
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 2, dku = 1)
     krbd = krbu - 1
     @ivy zrbd = ztfc[ir, jb, krbd]
     @ivy zrbu = ztfc[ir, jb, krbu]
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 2, dku = 1)
     krfd = krfu - 1
     @ivy zrfd = ztfc[ir, jf, krfd]
     @ivy zrfu = ztfc[ir, jf, krfu]
@@ -776,7 +776,7 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 2, dku = 1)
     klbd = klbu - 1
     @ivy zlbd =
         (
@@ -793,7 +793,7 @@ function interpolate_mean_flow(
             ztfc[il + 1, jb + 1, klbu]
         ) / 4
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 2, dku = 1)
     klfd = klfu - 1
     @ivy zlfd =
         (
@@ -810,7 +810,7 @@ function interpolate_mean_flow(
             ztfc[il + 1, jf + 1, klfu]
         ) / 4
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 2, dku = 1)
     krbd = krbu - 1
     @ivy zrbd =
         (
@@ -827,7 +827,7 @@ function interpolate_mean_flow(
             ztfc[ir + 1, jb + 1, krbu]
         ) / 4
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 2, dku = 1)
     krfd = krfu - 1
     @ivy zrfd =
         (
@@ -943,22 +943,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_half_level(il, jb, zlc, state)
+    klbu = get_next_half_level(il, jb, zlc, state; dkd = 1, dku = 1)
     klbd = klbu - 1
     @ivy zlbd = (ztildetfc[il, jb, klbd] + ztildetfc[il + 1, jb, klbd]) / 2
     @ivy zlbu = (ztildetfc[il, jb, klbu] + ztildetfc[il + 1, jb, klbu]) / 2
 
-    klfu = get_next_half_level(il, jf, zlc, state)
+    klfu = get_next_half_level(il, jf, zlc, state; dkd = 1, dku = 1)
     klfd = klfu - 1
     @ivy zlfd = (ztildetfc[il, jf, klfd] + ztildetfc[il + 1, jf, klfd]) / 2
     @ivy zlfu = (ztildetfc[il, jf, klfu] + ztildetfc[il + 1, jf, klfu]) / 2
 
-    krbu = get_next_half_level(ir, jb, zlc, state)
+    krbu = get_next_half_level(ir, jb, zlc, state; dkd = 1, dku = 1)
     krbd = krbu - 1
     @ivy zrbd = (ztildetfc[ir, jb, krbd] + ztildetfc[ir + 1, jb, krbd]) / 2
     @ivy zrbu = (ztildetfc[ir, jb, krbu] + ztildetfc[ir + 1, jb, krbu]) / 2
 
-    krfu = get_next_half_level(ir, jf, zlc, state)
+    krfu = get_next_half_level(ir, jf, zlc, state; dkd = 1, dku = 1)
     krfd = krfu - 1
     @ivy zrfd = (ztildetfc[ir, jf, krfd] + ztildetfc[ir + 1, jf, krfd]) / 2
     @ivy zrfu = (ztildetfc[ir, jf, krfu] + ztildetfc[ir + 1, jf, krfu]) / 2
@@ -1062,7 +1062,7 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 2, dku = 1)
     klbd = klbu - 1
     @ivy zlbd =
         (
@@ -1079,7 +1079,7 @@ function interpolate_mean_flow(
             ztfc[il + 1, jb + 1, klbu]
         ) / 4
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 2, dku = 1)
     klfd = klfu - 1
     @ivy zlfd =
         (
@@ -1096,7 +1096,7 @@ function interpolate_mean_flow(
             ztfc[il + 1, jf + 1, klfu]
         ) / 4
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 2, dku = 1)
     krbd = krbu - 1
     @ivy zrbd =
         (
@@ -1113,7 +1113,7 @@ function interpolate_mean_flow(
             ztfc[ir + 1, jb + 1, krbu]
         ) / 4
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 2, dku = 1)
     krfd = krfu - 1
     @ivy zrfd =
         (
@@ -1233,22 +1233,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 2, dku = 1)
     klbd = klbu - 1
     @ivy zlbd = ztfc[il, jb, klbd]
     @ivy zlbu = ztfc[il, jb, klbu]
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 2, dku = 1)
     klfd = klfu - 1
     @ivy zlfd = ztfc[il, jf, klfd]
     @ivy zlfu = ztfc[il, jf, klfu]
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 2, dku = 1)
     krbd = krbu - 1
     @ivy zrbd = ztfc[ir, jb, krbd]
     @ivy zrbu = ztfc[ir, jb, krbu]
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 2, dku = 1)
     krfd = krfu - 1
     @ivy zrfd = ztfc[ir, jf, krfd]
     @ivy zrfu = ztfc[ir, jf, krfu]
@@ -1352,22 +1352,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_half_level(il, jb, zlc, state)
+    klbu = get_next_half_level(il, jb, zlc, state; dkd = 1, dku = 1)
     klbd = klbu - 1
     @ivy zlbd = (ztildetfc[il, jb, klbd] + ztildetfc[il, jb + 1, klbd]) / 2
     @ivy zlbu = (ztildetfc[il, jb, klbu] + ztildetfc[il, jb + 1, klbu]) / 2
 
-    klfu = get_next_half_level(il, jf, zlc, state)
+    klfu = get_next_half_level(il, jf, zlc, state; dkd = 1, dku = 1)
     klfd = klfu - 1
     @ivy zlfd = (ztildetfc[il, jf, klfd] + ztildetfc[il, jf + 1, klfd]) / 2
     @ivy zlfu = (ztildetfc[il, jf, klfu] + ztildetfc[il, jf + 1, klfu]) / 2
 
-    krbu = get_next_half_level(ir, jb, zlc, state)
+    krbu = get_next_half_level(ir, jb, zlc, state; dkd = 1, dku = 1)
     krbd = krbu - 1
     @ivy zrbd = (ztildetfc[ir, jb, krbd] + ztildetfc[ir, jb + 1, krbd]) / 2
     @ivy zrbu = (ztildetfc[ir, jb, krbu] + ztildetfc[ir, jb + 1, krbu]) / 2
 
-    krfu = get_next_half_level(ir, jf, zlc, state)
+    krfu = get_next_half_level(ir, jf, zlc, state; dkd = 1, dku = 1)
     krfd = krfu - 1
     @ivy zrfd = (ztildetfc[ir, jf, krfd] + ztildetfc[ir, jf + 1, krfd]) / 2
     @ivy zrfu = (ztildetfc[ir, jf, krfu] + ztildetfc[ir, jf + 1, krfu]) / 2
@@ -1471,22 +1471,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 2, dku = 1)
     klbd = klbu - 1
     @ivy zlbd = (ztfc[il, jb, klbd] + ztfc[il + 1, jb, klbd]) / 2
     @ivy zlbu = (ztfc[il, jb, klbu] + ztfc[il + 1, jb, klbu]) / 2
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 2, dku = 1)
     klfd = klfu - 1
     @ivy zlfd = (ztfc[il, jf, klfd] + ztfc[il + 1, jf, klfd]) / 2
     @ivy zlfu = (ztfc[il, jf, klfu] + ztfc[il + 1, jf, klfu]) / 2
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 2, dku = 1)
     krbd = krbu - 1
     @ivy zrbd = (ztfc[ir, jb, krbd] + ztfc[ir + 1, jb, krbd]) / 2
     @ivy zrbu = (ztfc[ir, jb, krbu] + ztfc[ir + 1, jb, krbu]) / 2
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 2, dku = 1)
     krfd = krfu - 1
     @ivy zrfd = (ztfc[ir, jf, krfd] + ztfc[ir + 1, jf, krfd]) / 2
     @ivy zrfu = (ztfc[ir, jf, krfu] + ztfc[ir + 1, jf, krfu]) / 2
@@ -1589,22 +1589,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 2, dku = 1)
     klbd = klbu - 1
     @ivy zlbd = (ztfc[il, jf, klbd] + ztfc[il, jf + 1, klbd]) / 2
     @ivy zlbu = (ztfc[il, jf, klbu] + ztfc[il, jf + 1, klbu]) / 2
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 2, dku = 1)
     klfd = klfu - 1
     @ivy zlfd = (ztfc[il, jf, klfd] + ztfc[il, jf + 1, klfd]) / 2
     @ivy zlfu = (ztfc[il, jf, klfu] + ztfc[il, jf + 1, klfu]) / 2
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 2, dku = 1)
     krbd = krbu - 1
     @ivy zrbd = (ztfc[ir, jb, krbd] + ztfc[ir, jb + 1, krbd]) / 2
     @ivy zrbu = (ztfc[ir, jb, krbu] + ztfc[ir, jb + 1, krbu]) / 2
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 2, dku = 1)
     krfd = krfu - 1
     @ivy zrfd = (ztfc[ir, jf, krfd] + ztfc[ir, jf + 1, krfd]) / 2
     @ivy zrfu = (ztfc[ir, jf, krfu] + ztfc[ir, jf + 1, krfu]) / 2
@@ -1708,22 +1708,22 @@ function interpolate_mean_flow(
 
     # Locate the closest points in vertical direction.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 1, dku = 1)
     klbd = klbu - 1
     @ivy zlbd = ztildetfc[il, jb, klbd]
     @ivy zlbu = ztildetfc[il, jb, klbu]
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 1, dku = 1)
     klfd = klfu - 1
     @ivy zlfd = ztildetfc[il, jf, klfd]
     @ivy zlfu = ztildetfc[il, jf, klfu]
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 1, dku = 1)
     krbd = krbu - 1
     @ivy zrbd = ztildetfc[ir, jb, krbd]
     @ivy zrbu = ztildetfc[ir, jb, krbu]
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 1, dku = 1)
     krfd = krfu - 1
     @ivy zrfd = ztildetfc[ir, jf, krfd]
     @ivy zrfu = ztildetfc[ir, jf, krfu]

--- a/src/MSGWaM/Interpolation/interpolate_sponge.jl
+++ b/src/MSGWaM/Interpolation/interpolate_sponge.jl
@@ -67,22 +67,22 @@ function interpolate_sponge(
     # Determine closest points in vertical direction and set interpolation
     # values.
 
-    klbu = get_next_level(il, jb, zlc, state)
+    klbu = get_next_level(il, jb, zlc, state; dkd = 1)
     klbd = klbu - 1
     @ivy zlbd = ztfc[il, jb, klbd]
     @ivy zlbu = ztfc[il, jb, klbu]
 
-    klfu = get_next_level(il, jf, zlc, state)
+    klfu = get_next_level(il, jf, zlc, state; dkd = 1)
     klfd = klfu - 1
     @ivy zlfd = ztfc[il, jf, klfd]
     @ivy zlfu = ztfc[il, jf, klfu]
 
-    krbu = get_next_level(ir, jb, zlc, state)
+    krbu = get_next_level(ir, jb, zlc, state; dkd = 1)
     krbd = krbu - 1
     @ivy zrbd = ztfc[ir, jb, krbd]
     @ivy zrbu = ztfc[ir, jb, krbu]
 
-    krfu = get_next_level(ir, jf, zlc, state)
+    krfu = get_next_level(ir, jf, zlc, state; dkd = 1)
     krfd = krfu - 1
     @ivy zrfd = ztfc[ir, jf, krfd]
     @ivy zrfu = ztfc[ir, jf, krfu]

--- a/src/MSGWaM/Interpolation/interpolate_stratification.jl
+++ b/src/MSGWaM/Interpolation/interpolate_stratification.jl
@@ -49,7 +49,7 @@ function interpolate_stratification(
     (; i0, j0) = domain
     (; ztfc) = grid
 
-    ku = get_next_level(i0, j0, zlc, state)
+    ku = get_next_level(i0, j0, zlc, state; dkd = 1)
     kd = ku - 1
 
     @ivy zd = ztfc[i0, j0, kd]
@@ -89,7 +89,7 @@ function interpolate_stratification(
     (; i0, j0) = domain
     (; dz, ztildetfc, jac) = grid
 
-    ku = get_next_half_level(i0, j0, zlc, state)
+    ku = get_next_half_level(i0, j0, zlc, state; dkd = 1, dku = 1)
     kd = ku - 1
 
     @ivy zd = ztildetfc[i0, j0, kd]

--- a/src/MSGWaM/MeanFlowEffect/compute_gw_integrals!.jl
+++ b/src/MSGWaM/MeanFlowEffect/compute_gw_integrals!.jl
@@ -178,8 +178,20 @@ function compute_gw_integrals!(state::State, wkb_mode::MultiColumn)
                         fcpspy = 1.0
                     end
 
-                    kmin = get_next_half_level(iray, jray, zr - dzr / 2, state)
-                    kmax = get_next_half_level(iray, jray, zr + dzr / 2, state)
+                    kmin = get_next_half_level(
+                        iray,
+                        jray,
+                        zr - dzr / 2,
+                        state;
+                        dkd = 1,
+                    )
+                    kmax = get_next_half_level(
+                        iray,
+                        jray,
+                        zr + dzr / 2,
+                        state;
+                        dkd = 1,
+                    )
 
                     for kray in kmin:kmax
                         dzi =
@@ -360,8 +372,20 @@ function compute_gw_integrals!(state::State, wkb_mode::SingleColumn)
                         fcpspy = 1.0
                     end
 
-                    kmin = get_next_half_level(iray, jray, zr - dzr / 2, state)
-                    kmax = get_next_half_level(iray, jray, zr + dzr / 2, state)
+                    kmin = get_next_half_level(
+                        iray,
+                        jray,
+                        zr - dzr / 2,
+                        state;
+                        dkd = 1,
+                    )
+                    kmax = get_next_half_level(
+                        iray,
+                        jray,
+                        zr + dzr / 2,
+                        state;
+                        dkd = 1,
+                    )
 
                     for kray in kmin:kmax
                         dzi =
@@ -509,8 +533,20 @@ function compute_gw_integrals!(state::State, wkb_mode::SteadyState)
                         fcpspy = 1.0
                     end
 
-                    kmin = get_next_half_level(iray, jray, zr - dzr / 2, state)
-                    kmax = get_next_half_level(iray, jray, zr + dzr / 2, state)
+                    kmin = get_next_half_level(
+                        iray,
+                        jray,
+                        zr - dzr / 2,
+                        state;
+                        dkd = 1,
+                    )
+                    kmax = get_next_half_level(
+                        iray,
+                        jray,
+                        zr + dzr / 2,
+                        state;
+                        dkd = 1,
+                    )
 
                     for kray in kmin:kmax
                         dzi =

--- a/src/MSGWaM/RayUpdate/apply_saturation_scheme!.jl
+++ b/src/MSGWaM/RayUpdate/apply_saturation_scheme!.jl
@@ -79,8 +79,6 @@ is such that wave action is reduced exactly to the saturation threshold. The two
 
   - [`PinCFlow.MSGWaM.Interpolation.interpolate_stratification`](@ref)
 
-  - [`PinCFlow.MSGWaM.Interpolation.get_next_half_level`](@ref)
-
   - [`PinCFlow.MSGWaM.RayOperations.remove_rays!`](@ref)
 """
 function apply_saturation_scheme! end

--- a/src/MSGWaM/RayUpdate/shift_rays!.jl
+++ b/src/MSGWaM/RayUpdate/shift_rays!.jl
@@ -86,6 +86,8 @@ Ray volumes in halo cells are treated in the same way as in the methods for shif
   - [`PinCFlow.MSGWaM.RayOperations.check_rays`](@ref)
 
   - [`PinCFlow.MSGWaM.RayOperations.copy_rays!`](@ref)
+
+  - [`PinCFlow.MSGWaM.Interpolation.get_next_half_level`](@ref)
 """
 function shift_rays! end
 

--- a/src/MSGWaM/RayUpdate/split_rays!.jl
+++ b/src/MSGWaM/RayUpdate/split_rays!.jl
@@ -80,6 +80,8 @@ The splitting is analogous to that in ``\\widehat{x}`` and ``\\widehat{y}``.
 # See also
 
   - [`PinCFlow.MSGWaM.RayOperations.copy_rays!`](@ref)
+
+  - [`PinCFlow.MSGWaM.Interpolation.get_next_half_level`](@ref)
 """
 function split_rays! end
 


### PR DESCRIPTION
This fixes #89. Setting the default values of the keyword arguments to zero seemed more logical and easier to understand.