### PR TITLE
Peak process memory usage

### DIFF
--- a/src/Integration/integrate.jl
+++ b/src/Integration/integrate.jl
@@ -5,18 +5,11 @@ integrate(namelists::Namelists)
 
 Initialize the model state and integrate it in time.
 
-This method performs the complete time integration of the governing equations,
-using a semi-implicit time stepping scheme. It handles initialization,
-time stepping and output of the simulation data.
+This method performs the complete time integration of the governing equations, using a semi-implicit time stepping scheme. It handles initialization, time stepping and output of the simulation data.
 
 The initialization begins with the construction of the model state (an instance of the composite type `State`), which involves the setup of the MPI parallelization and the definition of all arrays that are needed repeatedly during the simulation. This is followed by an (optional) initial cleaning, in which the Poisson solver is called to ensure that the initial dynamic fields satisfy the divergence constraint imposed by the thermodynamic energy equation. Afterwards, the initialization of MS-GWaM is completed by adding ray volumes to the previously defined arrays. If the simulation is supposed to start from a previous model state, the fields are then overwritten with the data in the corresponding input file. Finally, the output file is created and the initial state is written into it.
 
-At the beginning of each time-loop iteration, the time step is determined from several stability criteria, using `compute_time_step`. 
-In case the updated simulation time is later than the next output time, the time step is corrected accordingly. 
-Subsequently, the damping coefficients of the sponges (which may depend on the time step) are calculated. 
-Following this, MS-GWaM updates the unresolved gravity-wave field and computes the corresponding mean-flow impact. 
-Then, the diffusion of momentum, mass-weighted potential temperature and tracers is applied.
-Afterwards, the resolved flow is updated in a semi-implicit time step, comprised of the following stages.
+At the beginning of each time-loop iteration, the time step is determined from several stability criteria, using `compute_time_step`. In case the updated simulation time is later than the next output time, the time step is corrected accordingly. Subsequently, the damping coefficients of the sponges (which may depend on the time step) are calculated. Following this, MS-GWaM updates the unresolved gravity-wave field and computes the corresponding mean-flow impact. Then, the diffusion of momentum, mass-weighted potential temperature and tracers is applied. Afterwards, the resolved flow is updated in a semi-implicit time step, comprised of the following stages.
 
  1. Explicit RK3 integration of LHS over ``\\Delta t / 2``.
 
@@ -270,7 +263,7 @@ function integrate(namelists::Namelists)
             wkb_integration!(state, dt)
 
             #-----------------------------------------------------------------
-            #                         Turbulence 
+            #                         Turbulence
             #-----------------------------------------------------------------
 
             turbulent_diffusion!(state, dt)

--- a/src/Integration/integrate.jl
+++ b/src/Integration/integrate.jl
@@ -412,12 +412,19 @@ function integrate(namelists::Namelists)
             end
         end
 
-        peak_rss = MPI.Allreduce(Sys.maxrss(), max, comm) / 1024^3
+        rss = Sys.maxrss() / 1024^3
+        peak_process_rss = MPI.Allreduce(rss, max, comm)
+        peak_total_rss = MPI.Allreduce(rss, +, comm)
         if master
             println(repeat("-", 80))
             println(
-                "Approximate peak single-process memory usage: ",
-                peak_rss,
+                "Approximate peak process memory usage: ",
+                peak_process_rss,
+                " GB",
+            )
+            println(
+                "Approximate peak total memory usage: ",
+                peak_total_rss,
                 " GB",
             )
             println(repeat("-", 80))

--- a/src/Integration/integrate.jl
+++ b/src/Integration/integrate.jl
@@ -419,10 +419,14 @@ function integrate(namelists::Namelists)
             end
         end
 
-        peak_rss = MPI.Allreduce(Sys.maxrss(), +, comm) / 1024^3
+        peak_rss = MPI.Allreduce(Sys.maxrss(), max, comm) / 1024^3
         if master
             println(repeat("-", 80))
-            println("Approximate peak memory usage: ", peak_rss, " GB")
+            println(
+                "Approximate peak single-process memory usage: ",
+                peak_rss,
+                " GB",
+            )
             println(repeat("-", 80))
             println("")
         end

--- a/src/Integration/integrate.jl
+++ b/src/Integration/integrate.jl
@@ -417,11 +417,7 @@ function integrate(namelists::Namelists)
         peak_total_rss = MPI.Allreduce(rss, +, comm)
         if master
             println(repeat("-", 80))
-            println(
-                "Approximate peak process memory usage: ",
-                peak_process_rss,
-                " GB",
-            )
+            println("Peak process memory usage: ", peak_process_rss, " GB")
             println(
                 "Approximate peak total memory usage: ",
                 peak_total_rss,


### PR DESCRIPTION
I've realized that the approximate peak total memory usage printed by `integrate`, while convenient for jobs run on a single node, is not particularly useful for jobs run on multiple nodes. For those, one needs the peak process memory usage, which `integrate` now also prints.