### PR TITLE
Removed a few runtime allocations in MS-GWaM.

### DIFF
--- a/src/MSGWaM/Interpolation/get_next_half_level.jl
+++ b/src/MSGWaM/Interpolation/get_next_half_level.jl
@@ -50,8 +50,8 @@ function get_next_half_level end
     (; nz, nzz, ko, k0, k1) = state.domain
     (; zctilde) = state.grid
 
-    k = argmin(abs.(zctilde[i, j, :] .- z))
-    if zctilde[i, j, k] < z
+    k = 1
+    while zctilde[i, j, k] < z
         k += 1
     end
 

--- a/src/MSGWaM/Interpolation/get_next_level.jl
+++ b/src/MSGWaM/Interpolation/get_next_level.jl
@@ -50,8 +50,8 @@ function get_next_level end
     (; nz, nzz, ko, k0, k1) = state.domain
     (; zc) = state.grid
 
-    k = argmin(abs.(zc[i, j, :] .- z))
-    if zc[i, j, k] < z
+    k = 1
+    while zc[i, j, k] < z
         k += 1
     end
 

--- a/src/Types/WKBTypes/getproperty.jl
+++ b/src/Types/WKBTypes/getproperty.jl
@@ -1,4 +1,4 @@
-@ivy function getproperty(
+@ivy @inline function getproperty(
     rays::Rays,
     name::Symbol,
 )::AbstractArray{<:AbstractFloat}


### PR DESCRIPTION
This PR removes a few runtime allocations in MS-GWaM which can become quite expensive. **In one particular configuration, removing them reduced the compute time from over 90 minutes to just under 3 minutes.** This was a situation where the allocations were particularly bad for memory access, so that speedup should not be expected for any simulation. Still, expensive MS-GWaM simulations should run noticeably faster.