### PR TITLE
Bug fix, docs, and tracer added to WKB wave packet test case

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -739,7 +739,7 @@ end
 
 ```
 
-initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates Furthermore, it initializes a tracer field that increases linearly with altitude and visualizes the parameterized, leading-order gravity-wave tracer flux convergence after ten minutes integration time (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations.
+initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates. Furthermore, it initializes a tracer field that increases linearly with altitude and visualizes the parameterized, leading-order gravity-wave tracer flux convergence after ten minutes integration time (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations.
 
 ![](examples/results/wkb_wave_packet.svg)
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -698,7 +698,7 @@ function wkb_wave_packet(;
     output = OutputNamelist(;
         output_file,
         output_interval = 600,
-        output_variables = [:uw],
+        output_variables = [:dchidt0],
         prepare_restart,
         tmax = 600,
     )
@@ -728,7 +728,7 @@ function wkb_wave_packet(;
         plot_output(
             plot_file,
             output_file,
-            (:uw, 0.5, 0.5, 0.5, 2);
+            (:dchidt0, 0.5, 0.5, 0.5, 2);
             display_figure,
             time_unit = :min,
         )
@@ -739,7 +739,7 @@ end
 
 ```
 
-initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates and visualizes the resulting zonal vertical-momentum flux after ten minutes integration time (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations. Furthermore, it initializes a tracer field that increases linearly with altitude, including parameterized, leading-order gravity-wave tracer fluxes.
+initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates Furthermore, it initializes a tracer field that increases linearly with altitude and visualizes the parameterized, leading-order gravity-wave tracer flux convergence (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations.
 
 ![](examples/results/wkb_wave_packet.svg)
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -716,7 +716,13 @@ function wkb_wave_packet(;
         ),
     )
 
-    integrate(Namelists(; atmosphere, domain, grid, output, wkb))
+    tracer = TracerNamelist(;
+        tracer_setup = :TracerOn,
+        leading_order_impact = true,
+        initial_chi = (x, y, z) -> z,
+    )
+
+    integrate(Namelists(; atmosphere, domain, grid, output, wkb, tracer))
 
     if visualize && MPI.Comm_rank(MPI.COMM_WORLD) == 0
         plot_output(
@@ -733,7 +739,7 @@ end
 
 ```
 
-initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates and visualizes the resulting zonal vertical-momentum flux after ten minutes integration time (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations.
+initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates and visualizes the resulting zonal vertical-momentum flux after ten minutes integration time (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations. Furthermore, it initializes a tracer field that increases linearly with altitude, including parameterized, leading-order gravity-wave tracer fluxes.
 
 ![](examples/results/wkb_wave_packet.svg)
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -739,7 +739,7 @@ end
 
 ```
 
-initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates Furthermore, it initializes a tracer field that increases linearly with altitude and visualizes the parameterized, leading-order gravity-wave tracer flux convergence (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations.
+initializes an unresolved gravity-wave packet (i.e. one that is parameterized by MS-GWaM) in the stratosphere of a compressible atmosphere with two different lapse rates Furthermore, it initializes a tracer field that increases linearly with altitude and visualizes the parameterized, leading-order gravity-wave tracer flux convergence after ten minutes integration time (see below). Like the wave-packet script discussed above, it constructs an auxiliary state and uses helper functions to satisfy the gravity-wave dispersion and polarization relations.
 
 ![](examples/results/wkb_wave_packet.svg)
 

--- a/docs/src/theory/numerics.md
+++ b/docs/src/theory/numerics.md
@@ -149,7 +149,7 @@ $$\begin{align*}
     2. && \left(\rho^\#, \rho'^\#, P^\#, \hat{\boldsymbol{u}}^\#, \pi'^\#\right) & = \mathrm{L}_{\Delta t / 2} \left(\rho^n, \rho'^n, P^n, \hat{\boldsymbol{u}}^n, \pi'^n, P^n, \hat{\boldsymbol{u}}^n, \alpha_\mathrm{R}^{n + 1}\right)\\
     3. && \left(\rho'^{n + 1 / 2}, \hat{\boldsymbol{u}}^{n + 1 / 2}, \pi'^{n + 1 / 2}\right) & = \mathrm{RI}_{\Delta t / 2} \left(\rho^\#, \rho'^\#, P^\#, \hat{\boldsymbol{u}}^\#, \pi'^\#, \beta_\mathrm{R}^{n + 1}\right)\\
     4. && \left(\rho'^*, \hat{\boldsymbol{u}}^*, \pi'^*\right) & = \mathrm{RE}_{\Delta t / 2} \left(\rho^n, \rho'^n, P^n, \hat{\boldsymbol{u}}^n, \pi'^n\right)\\
-    5. && \left(\rho^{**}, \rho'^{**}, P^{**}, \hat{\boldsymbol{u}}^{**}, \pi'^{**}\right) & = \mathrm{L}_{\Delta t} \left(\rho^n, \rho'^*, P^n, \hat{\boldsymbol{u}}^*, \pi'^{*}, P^\#, \hat{\boldsymbol{u}}^{n + 1 / 2}, \alpha_\mathrm{R}^{n + 1}\right)\\
+    5. && \left(\rho^{**}, \rho'^{**}, P^{**}, \hat{\boldsymbol{u}}^{**}, \pi'^{**}\right) & = \mathrm{L}_{\Delta t} \left(\rho^n, \rho'^*, P^n, \hat{\boldsymbol{u}}^*, \pi'^*, P^\#, \hat{\boldsymbol{u}}^{n + 1 / 2}, \alpha_\mathrm{R}^{n + 1}\right)\\
     6. && \left(\rho'^{n + 1}, \hat{\boldsymbol{u}}^{n + 1}, \pi'^{n + 1}\right) & = \mathrm{RI}_{\Delta t / 2} \left(\rho^{**}, \rho'^{**}, P^{**}, \hat{\boldsymbol{u}}^{**}, \pi'^{**}, 2 \beta_\mathrm{R}^{n + 1}\right)
 \end{align*}$$
 

--- a/docs/src/theory/numerics.md
+++ b/docs/src/theory/numerics.md
@@ -149,7 +149,7 @@ $$\begin{align*}
     2. && \left(\rho^\#, \rho'^\#, P^\#, \hat{\boldsymbol{u}}^\#, \pi'^\#\right) & = \mathrm{L}_{\Delta t / 2} \left(\rho^n, \rho'^n, P^n, \hat{\boldsymbol{u}}^n, \pi'^n, P^n, \hat{\boldsymbol{u}}^n, \alpha_\mathrm{R}^{n + 1}\right)\\
     3. && \left(\rho'^{n + 1 / 2}, \hat{\boldsymbol{u}}^{n + 1 / 2}, \pi'^{n + 1 / 2}\right) & = \mathrm{RI}_{\Delta t / 2} \left(\rho^\#, \rho'^\#, P^\#, \hat{\boldsymbol{u}}^\#, \pi'^\#, \beta_\mathrm{R}^{n + 1}\right)\\
     4. && \left(\rho'^*, \hat{\boldsymbol{u}}^*, \pi'^*\right) & = \mathrm{RE}_{\Delta t / 2} \left(\rho^n, \rho'^n, P^n, \hat{\boldsymbol{u}}^n, \pi'^n\right)\\
-    5. && \left(\rho^{**}, \rho'^{**}, P^{**}, \hat{\boldsymbol{u}}^{**}, \pi'^{**}\right) & = \mathrm{L}_{\Delta t} \left(\rho^n, \rho'^*, P^n, \hat{\boldsymbol{u}}^*, \pi'^{n + 1 / 2}, P^\#, \hat{\boldsymbol{u}}^{n + 1 / 2}, \alpha_\mathrm{R}^{n + 1}\right)\\
+    5. && \left(\rho^{**}, \rho'^{**}, P^{**}, \hat{\boldsymbol{u}}^{**}, \pi'^{**}\right) & = \mathrm{L}_{\Delta t} \left(\rho^n, \rho'^*, P^n, \hat{\boldsymbol{u}}^*, \pi'^{*}, P^\#, \hat{\boldsymbol{u}}^{n + 1 / 2}, \alpha_\mathrm{R}^{n + 1}\right)\\
     6. && \left(\rho'^{n + 1}, \hat{\boldsymbol{u}}^{n + 1}, \pi'^{n + 1}\right) & = \mathrm{RI}_{\Delta t / 2} \left(\rho^{**}, \rho'^{**}, P^{**}, \hat{\boldsymbol{u}}^{**}, \pi'^{**}, 2 \beta_\mathrm{R}^{n + 1}\right)
 \end{align*}$$
 
@@ -201,7 +201,7 @@ $$\begin{align*}
     After the last RK3 step, the Exner-pressure fluctuations are updated according to the Rayleigh damping applied to the mass-weighted potential temperature, i.e.
 
     $$\begin{align*}
-        \pi'^\# = \pi'^n - \alpha_\mathrm{R} \frac{\Delta t}{2} \left(P \frac{\partial \pi'}{\partial P}\right)^\# \left(1 - \frac{\bar{\rho}}{\rho^\#}\right),
+        \pi'^\# = \pi'^n - \alpha_\mathrm{R}^{n + 1} \frac{\Delta t}{2} \left(P \frac{\partial \pi'}{\partial P}\right)^\# \left(1 - \frac{\bar{\rho}}{\rho^\#}\right),
     \end{align*}$$
 
     where $\left(\partial P / \partial \pi'\right)^\# = \left(\gamma - 1\right)^{- 1} \left(R / p_\mathrm{ref}\right)^{1 - \gamma} \left(P^{2 - \gamma}\right)^\#$, with $\gamma$ being the ratio between the specific heat capacities and constant pressure and volume, $R$ being the specific gas constant and $p_\mathrm{ref}$ being the reference (ground) pressure.

--- a/src/Examples/wkb_wave_packet.jl
+++ b/src/Examples/wkb_wave_packet.jl
@@ -46,7 +46,7 @@ function wkb_wave_packet(;
     output = OutputNamelist(;
         output_file,
         output_interval = 600,
-        output_variables = [:uw],
+        output_variables = [:dchidt0],
         prepare_restart,
         tmax = 600,
     )
@@ -76,7 +76,7 @@ function wkb_wave_packet(;
         plot_output(
             plot_file,
             output_file,
-            (:uw, 0.5, 0.5, 0.5, 2);
+            (:dchidt0, 0.5, 0.5, 0.5, 2);
             display_figure,
             time_unit = :min,
         )

--- a/src/Examples/wkb_wave_packet.jl
+++ b/src/Examples/wkb_wave_packet.jl
@@ -64,7 +64,13 @@ function wkb_wave_packet(;
         ),
     )
 
-    integrate(Namelists(; atmosphere, domain, grid, output, wkb))
+    tracer = TracerNamelist(;
+        tracer_setup = :TracerOn,
+        leading_order_impact = true,
+        initial_chi = (x, y, z) -> z,
+    )
+
+    integrate(Namelists(; atmosphere, domain, grid, output, wkb, tracer))
 
     if visualize && MPI.Comm_rank(MPI.COMM_WORLD) == 0
         plot_output(

--- a/src/Output/create_output.jl
+++ b/src/Output/create_output.jl
@@ -588,16 +588,18 @@ function create_output(state::State, machine_start_time::DateTime)
             end
 
             if state.namelists.tracer.leading_order_impact &&
+               wkb_mode !== :NoWKB &&
                :dchidt0 in output_variables
                 attributes(file["dchidt0"])["units"] = "s^-1"
                 attributes(file["dchidt0"])["label"] =
-                    L"(\partial_t \chi_\mathrm{b})^{(0)}_\mathrm{w},[\mathrm{s^{-1}}]"
+                    L"(\partial_t \chi_\mathrm{b})^{(0)}_\mathrm{w}\ [\mathrm{s^{-1}}]"
                 attributes(
                     file["dchidt0"],
                 )["long_name"] = "leading-order GW-tracer flux convergence"
             end
 
             if state.namelists.tracer.leading_order_impact &&
+               wkb_mode !== :NoWKB &&
                :uchi0 in output_variables
                 attributes(file["uchi0"])["units"] = "m*s^-1"
                 attributes(file["uchi0"])["label"] =
@@ -608,6 +610,7 @@ function create_output(state::State, machine_start_time::DateTime)
             end
 
             if state.namelists.tracer.leading_order_impact &&
+               wkb_mode !== :NoWKB &&
                :vchi0 in output_variables
                 attributes(file["vchi0"])["units"] = "m*s^-1"
                 attributes(file["vchi0"])["label"] =
@@ -618,6 +621,7 @@ function create_output(state::State, machine_start_time::DateTime)
             end
 
             if state.namelists.tracer.leading_order_impact &&
+               wkb_mode !== :NoWKB &&
                :wchi0 in output_variables
                 attributes(file["wchi0"])["units"] = "m*s^-1"
                 attributes(file["wchi0"])["label"] =
@@ -631,7 +635,7 @@ function create_output(state::State, machine_start_time::DateTime)
         if state.namelists.turbulence.turbulence_scheme !== :NoTurbulence
             if prepare_restart || :tke in output_variables
                 attributes(file["tke"])["unuits"] = "m^2*s^-2"
-                attributes(file["tke"])["label"] = L"e_\\mathrm{k}"
+                attributes(file["tke"])["label"] = L"e_\\mathrm{k}\ [\mathrm{m^2\ s^{-2}}]"
                 attributes(
                     file["tke"],
                 )["long_name"] = "mass-specific turbulent kinetic energy"
@@ -640,14 +644,14 @@ function create_output(state::State, machine_start_time::DateTime)
             if :shear_production in output_variables
                 attributes(file["shear_production"])["unuits"] = "m^2*s^-3"
                 attributes(file["shear_production"])["label"] =
-                    L"\mathcal{S}"
+                    L"\mathcal{S}\ [\mathrm{m^2\ s^{-3}}]"
                 attributes(file["shear_production"])["long_name"] = "shear production"
             end
 
             if :buoyancy_production in output_variables
                 attributes(file["buoyancy_production"])["unuits"] = "m^2*s^-3"
                 attributes(file["buoyancy_production"])["label"] =
-                    L"\mathcal{B}"
+                    L"\mathcal{B}\ [\mathrm{m^2\ s^{-3}}]"
                 attributes(file["buoyancy_production"])["long_name"] = "buoyancy production"
             end
         end

--- a/src/Update/turbulent_diffusion!.jl
+++ b/src/Update/turbulent_diffusion!.jl
@@ -264,6 +264,12 @@ is solved using a Thomas tridiagonal solver, with ``\\mathcal{K}_\\mathrm{H} = \
   - [`PinCFlow.Update.thomas_algorithm!`](@ref)
 
   - [`PinCFlow.Update.turbulence_diffusion_coefficient`](@ref)
+
+  - [`PinCFlow.Boundaries.set_zonal_boundaries_of_field!`](@ref)
+
+  - [`PinCFlow.Boundaries.set_meridional_boundaries_of_field!`](@ref)
+
+  - [`PinCFlow.Boundaries.set_vertical_boundaries_of_field!`](@ref)
 """
 function turbulent_diffusion! end
 
@@ -311,8 +317,9 @@ function turbulent_diffusion!(
 end
 
 @ivy function turbulent_diffusion!(state::State, dt::AbstractFloat, variable::U)
+    (; namelists, domain) = state
     (; u) = state.variables.predictands
-    (; i0, i1, j0, j1, k0, k1) = state.domain
+    (; i0, i1, j0, j1, k0, k1) = domain
     (; jac, dz) = state.grid
     (; ath, bth, cth, fth) = state.variables.auxiliaries
 
@@ -417,12 +424,22 @@ end
     thomas_algorithm!(state)
 
     u[i0:i1, j0:j1, k0:k1] .= fth
+
+    set_zonal_boundaries_of_field!(u, namelists, domain)
+    set_vertical_boundaries_of_field!(
+        u,
+        namelists,
+        domain,
+        +;
+        layers = (1, 1, 1),
+    )
     return
 end
 
 @ivy function turbulent_diffusion!(state::State, dt::AbstractFloat, variable::V)
+    (; namelists, domain) = state
     (; v) = state.variables.predictands
-    (; i0, i1, j0, j1, k0, k1) = state.domain
+    (; i0, i1, j0, j1, k0, k1) = domain
     (; jac, dz) = state.grid
     (; ath, bth, cth, fth) = state.variables.auxiliaries
 
@@ -527,6 +544,15 @@ end
     thomas_algorithm!(state)
 
     v[i0:i1, j0:j1, k0:k1] .= fth
+
+    set_meridional_boundaries_of_field!(v, namelists, domain)
+    set_vertical_boundaries_of_field!(
+        v,
+        namelists,
+        domain,
+        +;
+        layers = (1, 1, 1),
+    )
     return
 end
 

--- a/test/test_wkb_wave_packet.jl
+++ b/test/test_wkb_wave_packet.jl
@@ -1,5 +1,6 @@
 function test_wkb_wave_packet()
     l2 = (
+        chi = 2.6328695f6,
         dkr = 0.0101921335f0,
         dlr = 0.01019214f0,
         dmr = 0.0048912093f0,
@@ -31,6 +32,7 @@ function test_wkb_wave_packet()
         ztilde = 1.9152024f6,
     )
     linf = (
+        chi = 29500.04f0,
         dkr = 0.0001834874f0,
         dlr = 0.00018348519f0,
         dmr = 9.167911f-5,

--- a/test/test_wkb_wave_packet.jl
+++ b/test/test_wkb_wave_packet.jl
@@ -1,6 +1,7 @@
 function test_wkb_wave_packet()
     l2 = (
         chi = 2.6328695f6,
+        dchidt0 = 0.00021973877f0,
         dkr = 0.0101921335f0,
         dlr = 0.01019214f0,
         dmr = 0.0048912093f0,
@@ -20,7 +21,6 @@ function test_wkb_wave_packet()
         thetabar = 57527.863f0,
         tke = 0.0063245553f0,
         us = 0.2104922f0,
-        uw = 0.10633506f0,
         vs = 0.20865981f0,
         wts = 0.017459119f0,
         x = 25787.594f0,
@@ -33,6 +33,7 @@ function test_wkb_wave_packet()
     )
     linf = (
         chi = 29500.04f0,
+        dchidt0 = 2.9074285f-5,
         dkr = 0.0001834874f0,
         dlr = 0.00018348519f0,
         dmr = 9.167911f-5,
@@ -52,7 +53,6 @@ function test_wkb_wave_packet()
         thetabar = 945.21136f0,
         tke = 5.000028f-5,
         us = 0.023524573f0,
-        uw = 0.019553408f0,
         vs = 0.02336692f0,
         wts = 0.0010166266f0,
         x = 9500.0f0,


### PR DESCRIPTION
This PR fixes #260. Additionally, I've fixed the two documentation issues in the "Numerics" section (see #192), as well as added a tracer to the function `wkb_wave_packet()`. That way we also cover the leading-order gravity-wave tracer fluxes in the tests.